### PR TITLE
Add business unit management page

### DIFF
--- a/src/api/bizUnit.js
+++ b/src/api/bizUnit.js
@@ -1,0 +1,21 @@
+import request from '@/utils/request'
+
+export function getBusinessUnitList(params = {}) {
+    return request.get('/biz-unit/list', { params })
+}
+
+export function createBusinessUnit(data) {
+    return request.post('/biz-unit', data)
+}
+
+export function editBusinessUnit(data) {
+    return request.put('/biz-unit', data)
+}
+
+export function deleteBusinessUnit(fid) {
+    return request.delete(`/biz-unit/${fid}`)
+}
+
+export function getBusinessUnitDetail(fid) {
+    return request.get(`/biz-unit/${fid}`)
+}

--- a/src/composables/login/enterprise-modeling/business-unit/useBusinessUnit.js
+++ b/src/composables/login/enterprise-modeling/business-unit/useBusinessUnit.js
@@ -1,0 +1,48 @@
+import { ref } from 'vue'
+import { getBusinessUnitList, createBusinessUnit as createApi, editBusinessUnit as editApi, deleteBusinessUnit as deleteApi } from '@/api/bizUnit.js'
+
+const UNIT_FIELDS = ['fid', 'fname', 'fcode', 'fmanagerid', 'fstatus']
+
+export function useBusinessUnit() {
+    const loading = ref(false)
+    const unitList = ref([])
+
+    const fetchBusinessUnitList = async () => {
+        loading.value = true
+        try {
+            const res = await getBusinessUnitList()
+            unitList.value = (res.data?.records || []).map(u => ({
+                ...UNIT_FIELDS.reduce((acc, k) => ({ ...acc, [k]: '' }), {}),
+                ...u
+            }))
+        } finally {
+            loading.value = false
+        }
+    }
+
+    const createBusinessUnit = async (unit) => {
+        const data = { ...unit }
+        delete data.fid
+        await createApi(data)
+        await fetchBusinessUnitList()
+    }
+
+    const editBusinessUnit = async (unit) => {
+        await editApi(unit)
+        await fetchBusinessUnitList()
+    }
+
+    const deleteBusinessUnit = async (unit) => {
+        await deleteApi(unit.fid)
+        await fetchBusinessUnitList()
+    }
+
+    return {
+        unitList,
+        loading,
+        fetchBusinessUnitList,
+        createBusinessUnit,
+        editBusinessUnit,
+        deleteBusinessUnit,
+    }
+}

--- a/src/composables/login/enterprise-modeling/useEnterpriseModeling.js
+++ b/src/composables/login/enterprise-modeling/useEnterpriseModeling.js
@@ -6,7 +6,7 @@ export function useEnterpriseModeling() {
             name: '组织人员',
             modules: [
                 { name: '人员', icon: '👤', path: '/personal' }, // 跳转人员管理
-                { name: '业务单元', icon: '🏢' },
+                { name: '业务单元', icon: '🏢', path: '/business-unit' },
                 { name: '部门维度管理', icon: '🏬' },
                 { name: '人员类型', icon: '👥' },
                 { name: '行政组织', icon: '🔗' }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,6 +4,7 @@ import Portal from '../views/login/Portal.vue';
 import Register from '../views/login/Register.vue';
 import EnterpriseModelingView from '../views/login/enterprise-modeling/EnterpriseModelingView.vue';
 import PersonalView from '../views/login/enterprise-modeling/persion/PersonalView.vue';
+import BusinessUnitView from '../views/login/enterprise-modeling/business-unit/BusinessUnitView.vue';
 
 // 临时空页面组件
 const EmptyView = {
@@ -67,6 +68,12 @@ const routes = [
         name: 'Personal',
         component: PersonalView,
         meta: { title: '人员管理' }
+    },
+    {
+        path: '/business-unit',
+        name: 'BusinessUnit',
+        component: BusinessUnitView,
+        meta: { title: '业务单元管理' }
     }
 ];
 

--- a/src/views/login/enterprise-modeling/business-unit/BusinessUnitView.vue
+++ b/src/views/login/enterprise-modeling/business-unit/BusinessUnitView.vue
@@ -1,0 +1,177 @@
+<template>
+  <div class="business-unit-page">
+    <v-card elevation="4" class="pa-6">
+      <div class="header">
+        <h2 class="title">业务单元管理</h2>
+        <v-btn color="primary" @click="openCreateDialog" prepend-icon="mdi-plus">
+          创建业务单元
+        </v-btn>
+      </div>
+
+      <v-data-table
+          :headers="headers"
+          :items="unitList"
+          :loading="loading"
+          loading-text="加载中..."
+          class="elevation-0"
+          item-key="fid"
+          hide-default-footer
+          dense
+      >
+        <template #item.actions="{ item }">
+          <v-btn size="small" color="primary" @click="openEditDialog(item)" variant="tonal">编辑</v-btn>
+          <v-btn size="small" color="error" @click="openDeleteDialog(item)" variant="tonal" class="ml-1">删除</v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="dialog.visible" max-width="600" persistent>
+      <v-card>
+        <v-card-title>{{ dialog.mode === 'create' ? '创建业务单元' : '编辑业务单元' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="dialog.valid">
+            <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v => !!v || '必填']" required />
+            <v-text-field v-model="dialog.form.fcode" label="编码" />
+            <v-text-field v-model="dialog.form.fmanagerid" label="负责人ID" />
+            <v-select v-model="dialog.form.fstatus" :items="['启用','停用','草稿']" label="状态" clearable />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">取消</v-btn>
+          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="350">
+      <v-card>
+        <v-card-title class="text-h6">确认删除</v-card-title>
+        <v-card-text>确认删除业务单元 <b>{{ deleteDialog.unit?.fname }}</b>？</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
+          <v-btn variant="text" color="error" @click="handleDeleteUnit">确定</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useBusinessUnit } from '@/composables/login/enterprise-modeling/business-unit/useBusinessUnit.js'
+
+const {
+  unitList,
+  loading,
+  fetchBusinessUnitList,
+  createBusinessUnit,
+  editBusinessUnit,
+  deleteBusinessUnit,
+} = useBusinessUnit()
+
+const headers = ref([
+  { title: '名称', value: 'fname', align: 'start' },
+  { title: '编码', value: 'fcode' },
+  { title: '负责人ID', value: 'fmanagerid' },
+  { title: '状态', value: 'fstatus' },
+  { title: '操作', value: 'actions', sortable: false, align: 'center', width: 150 },
+])
+
+const snackbar = reactive({
+  show: false,
+  text: '',
+  color: 'success',
+})
+
+const dialog = reactive({
+  visible: false,
+  mode: 'create',
+  form: {
+    fid: null,
+    fname: '',
+    fcode: '',
+    fmanagerid: '',
+    fstatus: '',
+  },
+  valid: false,
+  unitRef: null,
+})
+const formRef = ref()
+
+function openCreateDialog() {
+  dialog.visible = true
+  dialog.mode = 'create'
+  Object.assign(dialog.form, { fid: null, fname: '', fcode: '', fmanagerid: '', fstatus: '' })
+  dialog.unitRef = null
+}
+function openEditDialog(unit) {
+  dialog.visible = true
+  dialog.mode = 'edit'
+  Object.assign(dialog.form, { ...unit })
+  dialog.unitRef = unit
+}
+function closeDialog() {
+  dialog.visible = false
+  dialog.unitRef = null
+}
+async function handleConfirm() {
+  const validForm = await formRef.value?.validate?.()
+  if (!validForm) return
+  if (dialog.mode === 'create') {
+    await createBusinessUnit({ ...dialog.form })
+    showMsg('创建成功', 'success')
+  } else {
+    await editBusinessUnit({ ...dialog.form })
+    showMsg('业务单元已更新', 'success')
+  }
+  closeDialog()
+}
+
+const deleteDialog = reactive({
+  visible: false,
+  unit: null,
+})
+function openDeleteDialog(unit) {
+  deleteDialog.visible = true
+  deleteDialog.unit = unit
+}
+async function handleDeleteUnit() {
+  await deleteBusinessUnit(deleteDialog.unit)
+  showMsg('删除成功', 'success')
+  deleteDialog.visible = false
+}
+
+function showMsg(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+
+onMounted(() => {
+  fetchBusinessUnitList()
+})
+</script>
+
+<style scoped>
+.business-unit-page {
+  padding: 24px;
+}
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 22px;
+}
+.title {
+  font-size: 22px;
+  font-weight: bold;
+  color: #27324c;
+  letter-spacing: 2px;
+}
+</style>


### PR DESCRIPTION
## Summary
- create BusinessUnitView with listing and CRUD actions
- add useBusinessUnit composable for data handling
- add bizUnit api module
- wire business unit route and navigation

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6858b48b72e0832fbf4430d07b1b25e0