### PR TITLE
Add base data module

### DIFF
--- a/src/composables/base-data/useSimpleData.js
+++ b/src/composables/base-data/useSimpleData.js
@@ -1,0 +1,39 @@
+import { ref } from 'vue'
+import request from '@/utils/request'
+
+export function useSimpleData(basePath, fields = ['fid','fname','fcode']) {
+  const list = ref([])
+  const loading = ref(false)
+
+  const fetchList = async () => {
+    loading.value = true
+    try {
+      const res = await request.get(`${basePath}/list`)
+      list.value = (res.data?.records || []).map(i => ({
+        ...fields.reduce((a,k) => ({ ...a, [k]: '' }), {}),
+        ...i
+      }))
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const createItem = async (item) => {
+    const data = { ...item }
+    delete data.fid
+    await request.post(basePath, data)
+    await fetchList()
+  }
+
+  const editItem = async (item) => {
+    await request.put(basePath, item)
+    await fetchList()
+  }
+
+  const deleteItem = async (item) => {
+    await request.delete(`${basePath}/${item.fid}`)
+    await fetchList()
+  }
+
+  return { list, loading, fetchList, createItem, editItem, deleteItem }
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,6 +6,16 @@ import EnterpriseModelingView from '../views/login/enterprise-modeling/Enterpris
 import PersonalView from '../views/login/enterprise-modeling/persion/PersonalView.vue';
 import BusinessUnitView from '../views/login/enterprise-modeling/business-unit/BusinessUnitView.vue';
 import DeptDimensionView from '../views/login/enterprise-modeling/dept-dimension/DeptDimensionView.vue';
+import BaseDataView from '../views/login/base-data/BaseDataView.vue';
+import MaterialView from '../views/login/base-data/material/MaterialView.vue';
+import CustomerView from '../views/login/base-data/customer/CustomerView.vue';
+import SupplierView from '../views/login/base-data/supplier/SupplierView.vue';
+import CurrencyView from '../views/login/base-data/currency/CurrencyView.vue';
+import ExchangeRateView from '../views/login/base-data/exchange-rate/ExchangeRateView.vue';
+import BankInfoView from '../views/login/base-data/bank-info/BankInfoView.vue';
+import CountryView from '../views/login/base-data/country/CountryView.vue';
+import RegionView from '../views/login/base-data/region/RegionView.vue';
+import UnitView from '../views/login/base-data/unit/UnitView.vue';
 
 // 临时空页面组件
 const EmptyView = {
@@ -62,6 +72,12 @@ const routes = [
         component: EnterpriseModelingView,
         meta: { title: '企业建模' }
     },
+    {
+        path: '/base-data',
+        name: 'BaseData',
+        component: BaseDataView,
+        meta: { title: '基础资料' }
+    },
 
     // 人员管理 → 独立新页面
     {
@@ -81,7 +97,16 @@ const routes = [
         name: 'DepartmentDimension',
         component: DeptDimensionView,
         meta: { title: '部门维度管理' }
-    }
+    },
+    { path: '/material', name: 'Material', component: MaterialView, meta: { title: '物料管理' } },
+    { path: '/customer', name: 'Customer', component: CustomerView, meta: { title: '客户管理' } },
+    { path: '/supplier', name: 'Supplier', component: SupplierView, meta: { title: '供应商管理' } },
+    { path: '/currency', name: 'Currency', component: CurrencyView, meta: { title: '币种管理' } },
+    { path: '/exchange-rate', name: 'ExchangeRate', component: ExchangeRateView, meta: { title: '汇率管理' } },
+    { path: '/bank-info', name: 'BankInfo', component: BankInfoView, meta: { title: '行名行号管理' } },
+    { path: '/country', name: 'Country', component: CountryView, meta: { title: '国家管理' } },
+    { path: '/region', name: 'Region', component: RegionView, meta: { title: '地区管理' } },
+    { path: '/unit', name: 'Unit', component: UnitView, meta: { title: '计量单位管理' } }
 ];
 
 // 创建路由实例

--- a/src/views/login/Portal.vue
+++ b/src/views/login/Portal.vue
@@ -118,6 +118,7 @@ const modulesMap = {
   ],
   '基础服务云': [
     { name: '企业建模', path: '/enterprise-modeling', icon: '🏗️', desc: '企业业务建模' },
+    { name: '基础资料', path: '/base-data', icon: '📚', desc: '主数据与公共数据管理' },
   ],
 }
 

--- a/src/views/login/base-data/BaseDataView.vue
+++ b/src/views/login/base-data/BaseDataView.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="base-data-page">
+    <v-card v-for="group in groups" :key="group.name" class="group-card" elevation="2">
+      <div class="group-title">{{ group.name }}</div>
+      <v-row dense>
+        <v-col v-for="module in group.modules" :key="module.name" cols="12" sm="6" md="3" lg="2">
+          <v-card class="module-card" @click="handleModuleClick(module)" hover elevation="0" outlined>
+            <div class="module-icon">{{ module.icon }}</div>
+            <div class="module-name">{{ module.name }}</div>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-card>
+    <router-view></router-view>
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+const groups = ref([
+  {
+    name: '主数据',
+    modules: [
+      { name: '物料', icon: '📦', path: '/material' },
+      { name: '客户', icon: '🧑‍💼', path: '/customer' },
+      { name: '供应商', icon: '🏭', path: '/supplier' },
+    ]
+  },
+  {
+    name: '公共数据',
+    modules: [
+      { name: '币种', icon: '💱', path: '/currency' },
+      { name: '汇率', icon: '💹', path: '/exchange-rate' },
+      { name: '行名行号', icon: '🏦', path: '/bank-info' },
+      { name: '国家', icon: '🌍', path: '/country' },
+      { name: '地区', icon: '🗺️', path: '/region' },
+      { name: '计量单位', icon: '📏', path: '/unit' },
+    ]
+  }
+])
+
+const snackbar = ref({ show: false, text: '', color: 'info' })
+
+function handleModuleClick(module) {
+  if (module.path) {
+    router.push(module.path)
+  } else {
+    showMsg(`点击了模块：${module.name}`)
+  }
+}
+
+function showMsg(text, color = 'info') {
+  snackbar.value.text = text
+  snackbar.value.color = color
+  snackbar.value.show = true
+}
+</script>
+
+<style scoped>
+.base-data-page {
+  padding: 24px;
+}
+.group-card {
+  margin-bottom: 26px;
+  padding: 20px 16px 16px 16px;
+  border-radius: 16px;
+}
+.group-title {
+  font-size: 17px;
+  font-weight: bold;
+  margin-bottom: 19px;
+  color: #2850a7;
+  letter-spacing: 1.5px;
+}
+.module-card {
+  background-color: #fff;
+  border: 1.3px solid #e5eaf3 !important;
+  border-radius: 11px;
+  padding: 24px 0 16px 0;
+  text-align: center;
+  cursor: pointer;
+  transition: box-shadow 0.26s, transform 0.18s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 122px;
+}
+.module-card:hover {
+  box-shadow: 0 6px 20px rgba(71, 109, 200, 0.11);
+  transform: translateY(-3px) scale(1.04);
+  border-color: #90bafd !important;
+  background: #fafdff;
+}
+.module-icon {
+  font-size: 38px;
+  margin-bottom: 13px;
+}
+.module-name {
+  font-size: 15px;
+  color: #24457a;
+  font-weight: 500;
+  letter-spacing: 1px;
+}
+</style>

--- a/src/views/login/base-data/bank-info/BankInfoView.vue
+++ b/src/views/login/base-data/bank-info/BankInfoView.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="bank-info-page">
+    <v-card elevation="4" class="pa-6">
+      <div class="header">
+        <h2 class="title">行名行号管理</h2>
+        <v-btn color="primary" @click="openCreateDialog" prepend-icon="mdi-plus">创建行名行号</v-btn>
+      </div>
+      <v-data-table :headers="headers" :items="list" :loading="loading" class="elevation-0" item-key="fid" hide-default-footer dense>
+        <template #item.actions="{ item }">
+          <v-btn size="small" color="primary" variant="tonal" @click="openEditDialog(item)">编辑</v-btn>
+          <v-btn size="small" color="error" variant="tonal" class="ml-1" @click="openDeleteDialog(item)">删除</v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="dialog.visible" max-width="500" persistent>
+      <v-card>
+        <v-card-title>{{ dialog.mode === 'create' ? '创建行名行号' : '编辑行名行号' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="dialog.valid">
+            <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
+            <v-text-field v-model="dialog.form.fcode" label="编码" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">取消</v-btn>
+          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="350">
+      <v-card>
+        <v-card-title class="text-h6">确认删除</v-card-title>
+        <v-card-text>确认删除行名行号 <b>{{ deleteDialog.item?.fname }}</b>？</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
+          <v-btn variant="text" color="error" @click="handleDelete">确定</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useSimpleData } from '@/composables/base-data/useSimpleData'
+
+const { list, loading, fetchList, createItem, editItem, deleteItem } = useSimpleData('/bank-info')
+
+const headers = ref([
+  { title: '名称', value: 'fname', align: 'start' },
+  { title: '编码', value: 'fcode' },
+  { title: '操作', value: 'actions', sortable: false, align: 'center', width: 150 },
+])
+
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const dialog = reactive({
+  visible: false,
+  mode: 'create',
+  form: { fid: null, fname: '', fcode: '' },
+  valid: false,
+})
+const formRef = ref()
+
+function openCreateDialog() {
+  dialog.visible = true
+  dialog.mode = 'create'
+  Object.assign(dialog.form, { fid: null, fname: '', fcode: '' })
+}
+function openEditDialog(item) {
+  dialog.visible = true
+  dialog.mode = 'edit'
+  Object.assign(dialog.form, { ...item })
+}
+function closeDialog() {
+  dialog.visible = false
+}
+async function handleConfirm() {
+  const valid = await formRef.value?.validate?.()
+  if (!valid) return
+  if (dialog.mode === 'create') {
+    await createItem({ ...dialog.form })
+    showMsg('创建成功')
+  } else {
+    await editItem({ ...dialog.form })
+    showMsg('保存成功')
+  }
+  closeDialog()
+}
+const deleteDialog = reactive({ visible: false, item: null })
+function openDeleteDialog(item) {
+  deleteDialog.visible = true
+  deleteDialog.item = item
+}
+async function handleDelete() {
+  await deleteItem(deleteDialog.item)
+  showMsg('删除成功')
+  deleteDialog.visible = false
+}
+function showMsg(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+
+onMounted(() => {
+  fetchList()
+})
+</script>
+
+<style scoped>
+.bank-info-page { padding: 24px; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 22px; }
+.title { font-size: 22px; font-weight: bold; color: #27324c; letter-spacing: 2px; }
+</style>

--- a/src/views/login/base-data/country/CountryView.vue
+++ b/src/views/login/base-data/country/CountryView.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="country-page">
+    <v-card elevation="4" class="pa-6">
+      <div class="header">
+        <h2 class="title">国家管理</h2>
+        <v-btn color="primary" @click="openCreateDialog" prepend-icon="mdi-plus">创建国家</v-btn>
+      </div>
+      <v-data-table :headers="headers" :items="list" :loading="loading" class="elevation-0" item-key="fid" hide-default-footer dense>
+        <template #item.actions="{ item }">
+          <v-btn size="small" color="primary" variant="tonal" @click="openEditDialog(item)">编辑</v-btn>
+          <v-btn size="small" color="error" variant="tonal" class="ml-1" @click="openDeleteDialog(item)">删除</v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="dialog.visible" max-width="500" persistent>
+      <v-card>
+        <v-card-title>{{ dialog.mode === 'create' ? '创建国家' : '编辑国家' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="dialog.valid">
+            <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
+            <v-text-field v-model="dialog.form.fcode" label="编码" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">取消</v-btn>
+          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="350">
+      <v-card>
+        <v-card-title class="text-h6">确认删除</v-card-title>
+        <v-card-text>确认删除国家 <b>{{ deleteDialog.item?.fname }}</b>？</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
+          <v-btn variant="text" color="error" @click="handleDelete">确定</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useSimpleData } from '@/composables/base-data/useSimpleData'
+
+const { list, loading, fetchList, createItem, editItem, deleteItem } = useSimpleData('/country')
+
+const headers = ref([
+  { title: '名称', value: 'fname', align: 'start' },
+  { title: '编码', value: 'fcode' },
+  { title: '操作', value: 'actions', sortable: false, align: 'center', width: 150 },
+])
+
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const dialog = reactive({
+  visible: false,
+  mode: 'create',
+  form: { fid: null, fname: '', fcode: '' },
+  valid: false,
+})
+const formRef = ref()
+
+function openCreateDialog() {
+  dialog.visible = true
+  dialog.mode = 'create'
+  Object.assign(dialog.form, { fid: null, fname: '', fcode: '' })
+}
+function openEditDialog(item) {
+  dialog.visible = true
+  dialog.mode = 'edit'
+  Object.assign(dialog.form, { ...item })
+}
+function closeDialog() {
+  dialog.visible = false
+}
+async function handleConfirm() {
+  const valid = await formRef.value?.validate?.()
+  if (!valid) return
+  if (dialog.mode === 'create') {
+    await createItem({ ...dialog.form })
+    showMsg('创建成功')
+  } else {
+    await editItem({ ...dialog.form })
+    showMsg('保存成功')
+  }
+  closeDialog()
+}
+const deleteDialog = reactive({ visible: false, item: null })
+function openDeleteDialog(item) {
+  deleteDialog.visible = true
+  deleteDialog.item = item
+}
+async function handleDelete() {
+  await deleteItem(deleteDialog.item)
+  showMsg('删除成功')
+  deleteDialog.visible = false
+}
+function showMsg(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+
+onMounted(() => {
+  fetchList()
+})
+</script>
+
+<style scoped>
+.country-page { padding: 24px; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 22px; }
+.title { font-size: 22px; font-weight: bold; color: #27324c; letter-spacing: 2px; }
+</style>

--- a/src/views/login/base-data/currency/CurrencyView.vue
+++ b/src/views/login/base-data/currency/CurrencyView.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="currency-page">
+    <v-card elevation="4" class="pa-6">
+      <div class="header">
+        <h2 class="title">币种管理</h2>
+        <v-btn color="primary" @click="openCreateDialog" prepend-icon="mdi-plus">创建币种</v-btn>
+      </div>
+      <v-data-table :headers="headers" :items="list" :loading="loading" class="elevation-0" item-key="fid" hide-default-footer dense>
+        <template #item.actions="{ item }">
+          <v-btn size="small" color="primary" variant="tonal" @click="openEditDialog(item)">编辑</v-btn>
+          <v-btn size="small" color="error" variant="tonal" class="ml-1" @click="openDeleteDialog(item)">删除</v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="dialog.visible" max-width="500" persistent>
+      <v-card>
+        <v-card-title>{{ dialog.mode === 'create' ? '创建币种' : '编辑币种' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="dialog.valid">
+            <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
+            <v-text-field v-model="dialog.form.fcode" label="编码" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">取消</v-btn>
+          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="350">
+      <v-card>
+        <v-card-title class="text-h6">确认删除</v-card-title>
+        <v-card-text>确认删除币种 <b>{{ deleteDialog.item?.fname }}</b>？</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
+          <v-btn variant="text" color="error" @click="handleDelete">确定</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useSimpleData } from '@/composables/base-data/useSimpleData'
+
+const { list, loading, fetchList, createItem, editItem, deleteItem } = useSimpleData('/currency')
+
+const headers = ref([
+  { title: '名称', value: 'fname', align: 'start' },
+  { title: '编码', value: 'fcode' },
+  { title: '操作', value: 'actions', sortable: false, align: 'center', width: 150 },
+])
+
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const dialog = reactive({
+  visible: false,
+  mode: 'create',
+  form: { fid: null, fname: '', fcode: '' },
+  valid: false,
+})
+const formRef = ref()
+
+function openCreateDialog() {
+  dialog.visible = true
+  dialog.mode = 'create'
+  Object.assign(dialog.form, { fid: null, fname: '', fcode: '' })
+}
+function openEditDialog(item) {
+  dialog.visible = true
+  dialog.mode = 'edit'
+  Object.assign(dialog.form, { ...item })
+}
+function closeDialog() {
+  dialog.visible = false
+}
+async function handleConfirm() {
+  const valid = await formRef.value?.validate?.()
+  if (!valid) return
+  if (dialog.mode === 'create') {
+    await createItem({ ...dialog.form })
+    showMsg('创建成功')
+  } else {
+    await editItem({ ...dialog.form })
+    showMsg('保存成功')
+  }
+  closeDialog()
+}
+const deleteDialog = reactive({ visible: false, item: null })
+function openDeleteDialog(item) {
+  deleteDialog.visible = true
+  deleteDialog.item = item
+}
+async function handleDelete() {
+  await deleteItem(deleteDialog.item)
+  showMsg('删除成功')
+  deleteDialog.visible = false
+}
+function showMsg(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+
+onMounted(() => {
+  fetchList()
+})
+</script>
+
+<style scoped>
+.currency-page { padding: 24px; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 22px; }
+.title { font-size: 22px; font-weight: bold; color: #27324c; letter-spacing: 2px; }
+</style>

--- a/src/views/login/base-data/customer/CustomerView.vue
+++ b/src/views/login/base-data/customer/CustomerView.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="customer-page">
+    <v-card elevation="4" class="pa-6">
+      <div class="header">
+        <h2 class="title">客户管理</h2>
+        <v-btn color="primary" @click="openCreateDialog" prepend-icon="mdi-plus">创建客户</v-btn>
+      </div>
+      <v-data-table :headers="headers" :items="list" :loading="loading" class="elevation-0" item-key="fid" hide-default-footer dense>
+        <template #item.actions="{ item }">
+          <v-btn size="small" color="primary" variant="tonal" @click="openEditDialog(item)">编辑</v-btn>
+          <v-btn size="small" color="error" variant="tonal" class="ml-1" @click="openDeleteDialog(item)">删除</v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="dialog.visible" max-width="500" persistent>
+      <v-card>
+        <v-card-title>{{ dialog.mode === 'create' ? '创建客户' : '编辑客户' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="dialog.valid">
+            <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
+            <v-text-field v-model="dialog.form.fcode" label="编码" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">取消</v-btn>
+          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="350">
+      <v-card>
+        <v-card-title class="text-h6">确认删除</v-card-title>
+        <v-card-text>确认删除客户 <b>{{ deleteDialog.item?.fname }}</b>？</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
+          <v-btn variant="text" color="error" @click="handleDelete">确定</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useSimpleData } from '@/composables/base-data/useSimpleData'
+
+const { list, loading, fetchList, createItem, editItem, deleteItem } = useSimpleData('/customer')
+
+const headers = ref([
+  { title: '名称', value: 'fname', align: 'start' },
+  { title: '编码', value: 'fcode' },
+  { title: '操作', value: 'actions', sortable: false, align: 'center', width: 150 },
+])
+
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const dialog = reactive({
+  visible: false,
+  mode: 'create',
+  form: { fid: null, fname: '', fcode: '' },
+  valid: false,
+})
+const formRef = ref()
+
+function openCreateDialog() {
+  dialog.visible = true
+  dialog.mode = 'create'
+  Object.assign(dialog.form, { fid: null, fname: '', fcode: '' })
+}
+function openEditDialog(item) {
+  dialog.visible = true
+  dialog.mode = 'edit'
+  Object.assign(dialog.form, { ...item })
+}
+function closeDialog() {
+  dialog.visible = false
+}
+async function handleConfirm() {
+  const valid = await formRef.value?.validate?.()
+  if (!valid) return
+  if (dialog.mode === 'create') {
+    await createItem({ ...dialog.form })
+    showMsg('创建成功')
+  } else {
+    await editItem({ ...dialog.form })
+    showMsg('保存成功')
+  }
+  closeDialog()
+}
+const deleteDialog = reactive({ visible: false, item: null })
+function openDeleteDialog(item) {
+  deleteDialog.visible = true
+  deleteDialog.item = item
+}
+async function handleDelete() {
+  await deleteItem(deleteDialog.item)
+  showMsg('删除成功')
+  deleteDialog.visible = false
+}
+function showMsg(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+
+onMounted(() => {
+  fetchList()
+})
+</script>
+
+<style scoped>
+.customer-page { padding: 24px; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 22px; }
+.title { font-size: 22px; font-weight: bold; color: #27324c; letter-spacing: 2px; }
+</style>

--- a/src/views/login/base-data/exchange-rate/ExchangeRateView.vue
+++ b/src/views/login/base-data/exchange-rate/ExchangeRateView.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="exchange-rate-page">
+    <v-card elevation="4" class="pa-6">
+      <div class="header">
+        <h2 class="title">汇率管理</h2>
+        <v-btn color="primary" @click="openCreateDialog" prepend-icon="mdi-plus">创建汇率</v-btn>
+      </div>
+      <v-data-table :headers="headers" :items="list" :loading="loading" class="elevation-0" item-key="fid" hide-default-footer dense>
+        <template #item.actions="{ item }">
+          <v-btn size="small" color="primary" variant="tonal" @click="openEditDialog(item)">编辑</v-btn>
+          <v-btn size="small" color="error" variant="tonal" class="ml-1" @click="openDeleteDialog(item)">删除</v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="dialog.visible" max-width="500" persistent>
+      <v-card>
+        <v-card-title>{{ dialog.mode === 'create' ? '创建汇率' : '编辑汇率' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="dialog.valid">
+            <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
+            <v-text-field v-model="dialog.form.fcode" label="编码" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">取消</v-btn>
+          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="350">
+      <v-card>
+        <v-card-title class="text-h6">确认删除</v-card-title>
+        <v-card-text>确认删除汇率 <b>{{ deleteDialog.item?.fname }}</b>？</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
+          <v-btn variant="text" color="error" @click="handleDelete">确定</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useSimpleData } from '@/composables/base-data/useSimpleData'
+
+const { list, loading, fetchList, createItem, editItem, deleteItem } = useSimpleData('/exchange-rate')
+
+const headers = ref([
+  { title: '名称', value: 'fname', align: 'start' },
+  { title: '编码', value: 'fcode' },
+  { title: '操作', value: 'actions', sortable: false, align: 'center', width: 150 },
+])
+
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const dialog = reactive({
+  visible: false,
+  mode: 'create',
+  form: { fid: null, fname: '', fcode: '' },
+  valid: false,
+})
+const formRef = ref()
+
+function openCreateDialog() {
+  dialog.visible = true
+  dialog.mode = 'create'
+  Object.assign(dialog.form, { fid: null, fname: '', fcode: '' })
+}
+function openEditDialog(item) {
+  dialog.visible = true
+  dialog.mode = 'edit'
+  Object.assign(dialog.form, { ...item })
+}
+function closeDialog() {
+  dialog.visible = false
+}
+async function handleConfirm() {
+  const valid = await formRef.value?.validate?.()
+  if (!valid) return
+  if (dialog.mode === 'create') {
+    await createItem({ ...dialog.form })
+    showMsg('创建成功')
+  } else {
+    await editItem({ ...dialog.form })
+    showMsg('保存成功')
+  }
+  closeDialog()
+}
+const deleteDialog = reactive({ visible: false, item: null })
+function openDeleteDialog(item) {
+  deleteDialog.visible = true
+  deleteDialog.item = item
+}
+async function handleDelete() {
+  await deleteItem(deleteDialog.item)
+  showMsg('删除成功')
+  deleteDialog.visible = false
+}
+function showMsg(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+
+onMounted(() => {
+  fetchList()
+})
+</script>
+
+<style scoped>
+.exchange-rate-page { padding: 24px; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 22px; }
+.title { font-size: 22px; font-weight: bold; color: #27324c; letter-spacing: 2px; }
+</style>

--- a/src/views/login/base-data/material/MaterialView.vue
+++ b/src/views/login/base-data/material/MaterialView.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="material-page">
+    <v-card elevation="4" class="pa-6">
+      <div class="header">
+        <h2 class="title">物料管理</h2>
+        <v-btn color="primary" @click="openCreateDialog" prepend-icon="mdi-plus">创建物料</v-btn>
+      </div>
+      <v-data-table :headers="headers" :items="list" :loading="loading" class="elevation-0" item-key="fid" hide-default-footer dense>
+        <template #item.actions="{ item }">
+          <v-btn size="small" color="primary" variant="tonal" @click="openEditDialog(item)">编辑</v-btn>
+          <v-btn size="small" color="error" variant="tonal" class="ml-1" @click="openDeleteDialog(item)">删除</v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="dialog.visible" max-width="500" persistent>
+      <v-card>
+        <v-card-title>{{ dialog.mode === 'create' ? '创建物料' : '编辑物料' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="dialog.valid">
+            <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
+            <v-text-field v-model="dialog.form.fcode" label="编码" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">取消</v-btn>
+          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="350">
+      <v-card>
+        <v-card-title class="text-h6">确认删除</v-card-title>
+        <v-card-text>确认删除物料 <b>{{ deleteDialog.item?.fname }}</b>？</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
+          <v-btn variant="text" color="error" @click="handleDelete">确定</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useSimpleData } from '@/composables/base-data/useSimpleData'
+
+const { list, loading, fetchList, createItem, editItem, deleteItem } = useSimpleData('/material')
+
+const headers = ref([
+  { title: '名称', value: 'fname', align: 'start' },
+  { title: '编码', value: 'fcode' },
+  { title: '操作', value: 'actions', sortable: false, align: 'center', width: 150 },
+])
+
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const dialog = reactive({
+  visible: false,
+  mode: 'create',
+  form: { fid: null, fname: '', fcode: '' },
+  valid: false,
+})
+const formRef = ref()
+
+function openCreateDialog() {
+  dialog.visible = true
+  dialog.mode = 'create'
+  Object.assign(dialog.form, { fid: null, fname: '', fcode: '' })
+}
+function openEditDialog(item) {
+  dialog.visible = true
+  dialog.mode = 'edit'
+  Object.assign(dialog.form, { ...item })
+}
+function closeDialog() {
+  dialog.visible = false
+}
+async function handleConfirm() {
+  const valid = await formRef.value?.validate?.()
+  if (!valid) return
+  if (dialog.mode === 'create') {
+    await createItem({ ...dialog.form })
+    showMsg('创建成功')
+  } else {
+    await editItem({ ...dialog.form })
+    showMsg('保存成功')
+  }
+  closeDialog()
+}
+const deleteDialog = reactive({ visible: false, item: null })
+function openDeleteDialog(item) {
+  deleteDialog.visible = true
+  deleteDialog.item = item
+}
+async function handleDelete() {
+  await deleteItem(deleteDialog.item)
+  showMsg('删除成功')
+  deleteDialog.visible = false
+}
+function showMsg(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+
+onMounted(() => {
+  fetchList()
+})
+</script>
+
+<style scoped>
+.material-page { padding: 24px; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 22px; }
+.title { font-size: 22px; font-weight: bold; color: #27324c; letter-spacing: 2px; }
+</style>

--- a/src/views/login/base-data/region/RegionView.vue
+++ b/src/views/login/base-data/region/RegionView.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="region-page">
+    <v-card elevation="4" class="pa-6">
+      <div class="header">
+        <h2 class="title">地区管理</h2>
+        <v-btn color="primary" @click="openCreateDialog" prepend-icon="mdi-plus">创建地区</v-btn>
+      </div>
+      <v-data-table :headers="headers" :items="list" :loading="loading" class="elevation-0" item-key="fid" hide-default-footer dense>
+        <template #item.actions="{ item }">
+          <v-btn size="small" color="primary" variant="tonal" @click="openEditDialog(item)">编辑</v-btn>
+          <v-btn size="small" color="error" variant="tonal" class="ml-1" @click="openDeleteDialog(item)">删除</v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="dialog.visible" max-width="500" persistent>
+      <v-card>
+        <v-card-title>{{ dialog.mode === 'create' ? '创建地区' : '编辑地区' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="dialog.valid">
+            <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
+            <v-text-field v-model="dialog.form.fcode" label="编码" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">取消</v-btn>
+          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="350">
+      <v-card>
+        <v-card-title class="text-h6">确认删除</v-card-title>
+        <v-card-text>确认删除地区 <b>{{ deleteDialog.item?.fname }}</b>？</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
+          <v-btn variant="text" color="error" @click="handleDelete">确定</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useSimpleData } from '@/composables/base-data/useSimpleData'
+
+const { list, loading, fetchList, createItem, editItem, deleteItem } = useSimpleData('/region')
+
+const headers = ref([
+  { title: '名称', value: 'fname', align: 'start' },
+  { title: '编码', value: 'fcode' },
+  { title: '操作', value: 'actions', sortable: false, align: 'center', width: 150 },
+])
+
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const dialog = reactive({
+  visible: false,
+  mode: 'create',
+  form: { fid: null, fname: '', fcode: '' },
+  valid: false,
+})
+const formRef = ref()
+
+function openCreateDialog() {
+  dialog.visible = true
+  dialog.mode = 'create'
+  Object.assign(dialog.form, { fid: null, fname: '', fcode: '' })
+}
+function openEditDialog(item) {
+  dialog.visible = true
+  dialog.mode = 'edit'
+  Object.assign(dialog.form, { ...item })
+}
+function closeDialog() {
+  dialog.visible = false
+}
+async function handleConfirm() {
+  const valid = await formRef.value?.validate?.()
+  if (!valid) return
+  if (dialog.mode === 'create') {
+    await createItem({ ...dialog.form })
+    showMsg('创建成功')
+  } else {
+    await editItem({ ...dialog.form })
+    showMsg('保存成功')
+  }
+  closeDialog()
+}
+const deleteDialog = reactive({ visible: false, item: null })
+function openDeleteDialog(item) {
+  deleteDialog.visible = true
+  deleteDialog.item = item
+}
+async function handleDelete() {
+  await deleteItem(deleteDialog.item)
+  showMsg('删除成功')
+  deleteDialog.visible = false
+}
+function showMsg(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+
+onMounted(() => {
+  fetchList()
+})
+</script>
+
+<style scoped>
+.region-page { padding: 24px; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 22px; }
+.title { font-size: 22px; font-weight: bold; color: #27324c; letter-spacing: 2px; }
+</style>

--- a/src/views/login/base-data/supplier/SupplierView.vue
+++ b/src/views/login/base-data/supplier/SupplierView.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="supplier-page">
+    <v-card elevation="4" class="pa-6">
+      <div class="header">
+        <h2 class="title">供应商管理</h2>
+        <v-btn color="primary" @click="openCreateDialog" prepend-icon="mdi-plus">创建供应商</v-btn>
+      </div>
+      <v-data-table :headers="headers" :items="list" :loading="loading" class="elevation-0" item-key="fid" hide-default-footer dense>
+        <template #item.actions="{ item }">
+          <v-btn size="small" color="primary" variant="tonal" @click="openEditDialog(item)">编辑</v-btn>
+          <v-btn size="small" color="error" variant="tonal" class="ml-1" @click="openDeleteDialog(item)">删除</v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="dialog.visible" max-width="500" persistent>
+      <v-card>
+        <v-card-title>{{ dialog.mode === 'create' ? '创建供应商' : '编辑供应商' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="dialog.valid">
+            <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
+            <v-text-field v-model="dialog.form.fcode" label="编码" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">取消</v-btn>
+          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="350">
+      <v-card>
+        <v-card-title class="text-h6">确认删除</v-card-title>
+        <v-card-text>确认删除供应商 <b>{{ deleteDialog.item?.fname }}</b>？</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
+          <v-btn variant="text" color="error" @click="handleDelete">确定</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useSimpleData } from '@/composables/base-data/useSimpleData'
+
+const { list, loading, fetchList, createItem, editItem, deleteItem } = useSimpleData('/supplier')
+
+const headers = ref([
+  { title: '名称', value: 'fname', align: 'start' },
+  { title: '编码', value: 'fcode' },
+  { title: '操作', value: 'actions', sortable: false, align: 'center', width: 150 },
+])
+
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const dialog = reactive({
+  visible: false,
+  mode: 'create',
+  form: { fid: null, fname: '', fcode: '' },
+  valid: false,
+})
+const formRef = ref()
+
+function openCreateDialog() {
+  dialog.visible = true
+  dialog.mode = 'create'
+  Object.assign(dialog.form, { fid: null, fname: '', fcode: '' })
+}
+function openEditDialog(item) {
+  dialog.visible = true
+  dialog.mode = 'edit'
+  Object.assign(dialog.form, { ...item })
+}
+function closeDialog() {
+  dialog.visible = false
+}
+async function handleConfirm() {
+  const valid = await formRef.value?.validate?.()
+  if (!valid) return
+  if (dialog.mode === 'create') {
+    await createItem({ ...dialog.form })
+    showMsg('创建成功')
+  } else {
+    await editItem({ ...dialog.form })
+    showMsg('保存成功')
+  }
+  closeDialog()
+}
+const deleteDialog = reactive({ visible: false, item: null })
+function openDeleteDialog(item) {
+  deleteDialog.visible = true
+  deleteDialog.item = item
+}
+async function handleDelete() {
+  await deleteItem(deleteDialog.item)
+  showMsg('删除成功')
+  deleteDialog.visible = false
+}
+function showMsg(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+
+onMounted(() => {
+  fetchList()
+})
+</script>
+
+<style scoped>
+.supplier-page { padding: 24px; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 22px; }
+.title { font-size: 22px; font-weight: bold; color: #27324c; letter-spacing: 2px; }
+</style>

--- a/src/views/login/base-data/unit/UnitView.vue
+++ b/src/views/login/base-data/unit/UnitView.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="unit-page">
+    <v-card elevation="4" class="pa-6">
+      <div class="header">
+        <h2 class="title">计量单位管理</h2>
+        <v-btn color="primary" @click="openCreateDialog" prepend-icon="mdi-plus">创建计量单位</v-btn>
+      </div>
+      <v-data-table :headers="headers" :items="list" :loading="loading" class="elevation-0" item-key="fid" hide-default-footer dense>
+        <template #item.actions="{ item }">
+          <v-btn size="small" color="primary" variant="tonal" @click="openEditDialog(item)">编辑</v-btn>
+          <v-btn size="small" color="error" variant="tonal" class="ml-1" @click="openDeleteDialog(item)">删除</v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="dialog.visible" max-width="500" persistent>
+      <v-card>
+        <v-card-title>{{ dialog.mode === 'create' ? '创建计量单位' : '编辑计量单位' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="dialog.valid">
+            <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
+            <v-text-field v-model="dialog.form.fcode" label="编码" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">取消</v-btn>
+          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="350">
+      <v-card>
+        <v-card-title class="text-h6">确认删除</v-card-title>
+        <v-card-text>确认删除计量单位 <b>{{ deleteDialog.item?.fname }}</b>？</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
+          <v-btn variant="text" color="error" @click="handleDelete">确定</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useSimpleData } from '@/composables/base-data/useSimpleData'
+
+const { list, loading, fetchList, createItem, editItem, deleteItem } = useSimpleData('/unit')
+
+const headers = ref([
+  { title: '名称', value: 'fname', align: 'start' },
+  { title: '编码', value: 'fcode' },
+  { title: '操作', value: 'actions', sortable: false, align: 'center', width: 150 },
+])
+
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const dialog = reactive({
+  visible: false,
+  mode: 'create',
+  form: { fid: null, fname: '', fcode: '' },
+  valid: false,
+})
+const formRef = ref()
+
+function openCreateDialog() {
+  dialog.visible = true
+  dialog.mode = 'create'
+  Object.assign(dialog.form, { fid: null, fname: '', fcode: '' })
+}
+function openEditDialog(item) {
+  dialog.visible = true
+  dialog.mode = 'edit'
+  Object.assign(dialog.form, { ...item })
+}
+function closeDialog() {
+  dialog.visible = false
+}
+async function handleConfirm() {
+  const valid = await formRef.value?.validate?.()
+  if (!valid) return
+  if (dialog.mode === 'create') {
+    await createItem({ ...dialog.form })
+    showMsg('创建成功')
+  } else {
+    await editItem({ ...dialog.form })
+    showMsg('保存成功')
+  }
+  closeDialog()
+}
+const deleteDialog = reactive({ visible: false, item: null })
+function openDeleteDialog(item) {
+  deleteDialog.visible = true
+  deleteDialog.item = item
+}
+async function handleDelete() {
+  await deleteItem(deleteDialog.item)
+  showMsg('删除成功')
+  deleteDialog.visible = false
+}
+function showMsg(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+
+onMounted(() => {
+  fetchList()
+})
+</script>
+
+<style scoped>
+.unit-page { padding: 24px; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 22px; }
+.title { font-size: 22px; font-weight: bold; color: #27324c; letter-spacing: 2px; }
+</style>


### PR DESCRIPTION
## Summary
- add Basic Data module to the portal
- support routes for basic data management
- implement simple data list pages for materials, customers, suppliers, etc.
- add generic `useSimpleData` composable

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6858cc1142c4832f956c1d483126c211