### PR TITLE
Add finance cloud AR/AP modules

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -65,6 +65,13 @@ const routes = [
     { path: '/ledger', component: EmptyView, meta: { title: '总账' } },
     { path: '/cost', component: EmptyView, meta: { title: '费用核算' } },
     { path: '/reports', component: EmptyView, meta: { title: '财务报表' } },
+    { path: '/payable', component: EmptyView, meta: { title: '应付' } },
+    { path: '/estimated-payable', component: EmptyView, meta: { title: '暂估应付' } },
+    { path: '/payment-application', component: EmptyView, meta: { title: '付款申请' } },
+    { path: '/payment-processing', component: EmptyView, meta: { title: '付款处理' } },
+    { path: '/receivable', component: EmptyView, meta: { title: '应收' } },
+    { path: '/estimated-receivable', component: EmptyView, meta: { title: '暂估应收' } },
+    { path: '/settlement-processing', component: EmptyView, meta: { title: '结算处理' } },
 
     {
         path: '/enterprise-modeling',

--- a/src/views/login/Portal.vue
+++ b/src/views/login/Portal.vue
@@ -115,6 +115,13 @@ const modulesMap = {
     { name: '总账', path: '/ledger', icon: '📚', desc: '总账处理与报表' },
     { name: '费用核算', path: '/cost', icon: '💼', desc: '费用核算流程' },
     { name: '财务报表', path: '/reports', icon: '📊', desc: '财务分析报表' },
+    { name: '应付', path: '/payable', icon: '💳', desc: '应付业务管理' },
+    { name: '暂估应付', path: '/estimated-payable', icon: '⌛', desc: '应付暂估管理' },
+    { name: '付款申请', path: '/payment-application', icon: '📝', desc: '付款申请流程' },
+    { name: '付款处理', path: '/payment-processing', icon: '💵', desc: '付款执行处理' },
+    { name: '应收', path: '/receivable', icon: '💰', desc: '应收业务管理' },
+    { name: '暂估应收', path: '/estimated-receivable', icon: '⏳', desc: '应收暂估管理' },
+    { name: '结算处理', path: '/settlement-processing', icon: '🔄', desc: '结算清算处理' },
   ],
   '基础服务云': [
     { name: '企业建模', path: '/enterprise-modeling', icon: '🏗️', desc: '企业业务建模' },


### PR DESCRIPTION
## Summary
- expand 财务云 module list with 应收/应付功能
- register placeholder routes for new modules

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858ebc6364c832f994772e00954d4cf