### PR TITLE
Implement auth guard with auto logout

### DIFF
--- a/src/composables/login/useLogin.js
+++ b/src/composables/login/useLogin.js
@@ -7,6 +7,7 @@ import {
     checkQrStatus,
     sendSmsCode,
 } from '@/api/auth.js'
+import { saveToken } from '@/utils/auth'
 
 export function useLogin(router, snackbar) {
     const activeTab = ref('account')
@@ -77,6 +78,8 @@ export function useLogin(router, snackbar) {
             try {
                 const res = await checkQrStatus(form.qrcode.token)
                 if (res.data?.status === 'success') {
+                    const token = res.data?.token
+                    if (token) saveToken(token)
                     showMsg('扫码登录成功', 'success')
                     clearInterval(form.qrcode.pollingTimer)
                     form.qrcode.pollingTimer = null
@@ -143,7 +146,9 @@ export function useLogin(router, snackbar) {
             if (valid) {
                 loading.value = true
                 try {
-                    await loginByAccount({ ...form.account })
+                    const res = await loginByAccount({ ...form.account })
+                    const token = res?.token || res?.data?.token
+                    if (token) saveToken(token)
                     showMsg('登录成功', 'success')
                     resetAll()
                     router.push('/portal')
@@ -159,7 +164,9 @@ export function useLogin(router, snackbar) {
             if (valid) {
                 loading.value = true
                 try {
-                    await loginByPhone({ ...form.phone })
+                    const res = await loginByPhone({ ...form.phone })
+                    const token = res?.token || res?.data?.token
+                    if (token) saveToken(token)
                     showMsg('登录成功', 'success')
                     resetAll()
                     router.push('/portal')

--- a/src/main.js
+++ b/src/main.js
@@ -5,9 +5,11 @@ import App from './App.vue'
 
 import vuetify from './plugins/vuetify'
 import router from './router'
+import { initAuth } from './utils/auth'
 
 const app = createApp(App)
 // app.use(ElementPlus)
 app.use(vuetify)
 app.use(router)
+initAuth(router)
 app.mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -138,16 +138,21 @@ const router = createRouter({
 });
 
 // 全局前置守卫
+import { updateActivity } from '@/utils/auth'
+
 router.beforeEach((to, from, next) => {
     // 设置页面 title
     if (to.meta?.title) {
         document.title = to.meta.title;
     }
 
-    // 示例逻辑（后期可做鉴权）
-    // if (to.path !== '/' && !localStorage.getItem('token')) {
-    //     return next('/');
-    // }
+    const publicPages = ['/', '/login', '/register']
+    const token = localStorage.getItem('token')
+    if (!token && !publicPages.includes(to.path)) {
+        return next('/login')
+    }
+
+    if (token) updateActivity()
 
     next();
 });

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,30 @@
+export function saveToken(token) {
+    if (token) {
+        localStorage.setItem('token', token)
+        localStorage.setItem('lastActivityTime', Date.now().toString())
+    }
+}
+
+export function clearToken() {
+    localStorage.removeItem('token')
+    localStorage.removeItem('lastActivityTime')
+}
+
+export function updateActivity() {
+    localStorage.setItem('lastActivityTime', Date.now().toString())
+}
+
+export function initAuth(router) {
+    const events = ['mousemove', 'keydown', 'click', 'scroll']
+    const reset = () => updateActivity()
+    events.forEach(ev => window.addEventListener(ev, reset))
+    setInterval(() => {
+        const token = localStorage.getItem('token')
+        const last = parseInt(localStorage.getItem('lastActivityTime'))
+        if (token && last && Date.now() - last > 3600000) {
+            clearToken()
+            router.push('/login')
+        }
+    }, 60000)
+    updateActivity()
+}

--- a/src/views/login/Portal.vue
+++ b/src/views/login/Portal.vue
@@ -80,6 +80,7 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { clearToken } from '@/utils/auth'
 
 const router = useRouter()
 
@@ -147,7 +148,8 @@ function handleLogout() {
     text: '已退出登录',
     color: 'success',
   }
-  setTimeout(() => router.push('/'), 900)
+  clearToken()
+  setTimeout(() => router.push('/login'), 900)
 }
 </script>
 


### PR DESCRIPTION
## Summary
- add authentication utilities and inactivity logout handler
- initialize authentication in main entrypoint
- protect routes and refresh activity timestamp on navigation
- store token after login and implement logout behavior

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685be01a0718832f801c836e6a2a21cd