### PR TITLE
Open modules in new tabs

### DIFF
--- a/src/views/login/Portal.vue
+++ b/src/views/login/Portal.vue
@@ -134,12 +134,9 @@ const snackbar = ref({
 })
 
 function navigateTo(path) {
-  snackbar.value = {
-    show: true,
-    text: `跳转到 ${path} 页面`,
-    color: 'info',
-  }
-  setTimeout(() => router.push(path), 800)
+  // 打开新标签页访问目标路由
+  const url = router.resolve(path).href
+  window.open(url, '_blank')
 }
 
 function handleLogout() {

--- a/src/views/login/base-data/BaseDataView.vue
+++ b/src/views/login/base-data/BaseDataView.vue
@@ -50,7 +50,8 @@ const snackbar = ref({ show: false, text: '', color: 'info' })
 
 function handleModuleClick(module) {
   if (module.path) {
-    router.push(module.path)
+    const url = router.resolve(module.path).href
+    window.open(url, '_blank')
   } else {
     showMsg(`点击了模块：${module.name}`)
   }

--- a/src/views/login/enterprise-modeling/EnterpriseModelingView.vue
+++ b/src/views/login/enterprise-modeling/EnterpriseModelingView.vue
@@ -65,7 +65,9 @@ const snackbar = ref({
 
 function handleModuleClick(module) {
   if (module.path) {
-    router.push(module.path)
+    // 使用新标签页打开目标路由
+    const url = router.resolve(module.path).href
+    window.open(url, '_blank')
   } else {
     showMsg(`点击了模块：${module.name}`, 'info')
   }

--- a/src/views/login/finance/PayableView.vue
+++ b/src/views/login/finance/PayableView.vue
@@ -42,7 +42,8 @@ const snackbar = ref({ show: false, text: '', color: 'info' })
 
 function handleModuleClick(module) {
   if (module.path) {
-    router.push(module.path)
+    const url = router.resolve(module.path).href
+    window.open(url, '_blank')
   } else {
     snackbar.value = {
       show: true,

--- a/src/views/login/finance/ReceivableView.vue
+++ b/src/views/login/finance/ReceivableView.vue
@@ -41,7 +41,8 @@ const snackbar = ref({ show: false, text: '', color: 'info' })
 
 function handleModuleClick(module) {
   if (module.path) {
-    router.push(module.path)
+    const url = router.resolve(module.path).href
+    window.open(url, '_blank')
   } else {
     snackbar.value = {
       show: true,


### PR DESCRIPTION
## Summary
- open cloud modules in a new browser tab
- open enterprise modeling modules in a new browser tab
- open base data modules in a new browser tab
- open payable and receivable modules in a new browser tab

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686226647b08832f98616ddd70db2f5c