### PR TITLE
Add account subject form page

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -21,6 +21,7 @@ import ReceivableView from '../views/login/finance/ReceivableView.vue';
 import GeneralLedgerView from '../views/login/ledger/GeneralLedgerView.vue';
 import FinanceBaseDataView from '../views/login/finance/base-data/FinanceBaseDataView.vue';
 import AccountSubjectView from '../views/login/finance/base-data/AccountSubjectView.vue';
+import AccountSubjectForm from '../views/login/finance/base-data/account-subject/AccountSubjectForm.vue';
 
 
 // 临时空页面组件
@@ -71,6 +72,7 @@ const routes = [
     { path: '/ledger', name: 'Ledger', component: GeneralLedgerView, meta: { title: '总账' } },
     { path: '/finance/base-data', name: 'FinanceBaseData', component: FinanceBaseDataView, meta: { title: '基础资料' } },
     { path: '/finance/base-data/account-subject', name: 'AccountSubject', component: AccountSubjectView, meta: { title: '会计科目' } },
+    { path: '/finance/base-data/account-subject/form/:fid?', name: 'AccountSubjectForm', component: AccountSubjectForm, meta: { title: '科目维护' } },
     { path: '/cost', component: EmptyView, meta: { title: '费用核算' } },
     { path: '/reports', component: EmptyView, meta: { title: '财务报表' } },
     { path: '/payable', component: EmptyView, meta: { title: '应付' } },

--- a/src/views/login/finance/base-data/AccountSubjectView.vue
+++ b/src/views/login/finance/base-data/AccountSubjectView.vue
@@ -13,88 +13,6 @@
       </v-data-table>
     </v-card>
 
-    <v-dialog v-model="dialog.visible" max-width="600" persistent>
-      <v-card>
-        <v-card-title>{{ dialog.mode === 'create' ? '创建科目' : '编辑科目' }}</v-card-title>
-        <v-card-text>
-          <v-form ref="formRef" v-model="dialog.valid">
-            <v-row dense>
-              <v-col cols="12" md="6">
-                <v-text-field v-model="dialog.form.fcode" label="编码" :rules="[v=>!!v||'必填']" required />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-select v-model="dialog.form.forg" :items="orgOptions" label="核算组织" required />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-text-field v-model="dialog.form.flongName" label="长名称" />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-select v-model="dialog.form.ftype" :items="acctTypeOptions" label="科目类型" required />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-autocomplete v-model="dialog.form.fparent" :items="subjectOptions" label="上级" clearable />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-select v-model="dialog.form.fpltype" :items="profitLossOptions" label="损益类型" />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-select v-model="dialog.form.fdirection" :items="['借','贷']" label="余额方向" required />
-              </v-col>
-              <v-col cols="12" md="6" class="d-flex align-center">
-                <v-checkbox v-model="dialog.form.fisDetail" label="明细科目" />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-autocomplete v-model="dialog.form.freportItem" :items="reportItemOptions" label="报表项目" clearable />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-autocomplete v-model="dialog.form.flevel1" :items="level1Options" label="一级科目" clearable />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-select v-model="dialog.form.fentryControl" :items="entryControlOptions" label="科目录入方向控制" required />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-select v-model="dialog.form.fcontrolLevel" :items="controlLevelOptions" label="控制级次" />
-              </v-col>
-              <v-col cols="12" md="6" class="d-flex align-center">
-                <v-checkbox v-model="dialog.form.fallowChild" label="允许公司增加下级科目" />
-              </v-col>
-              <v-col cols="12" md="6" class="d-flex align-center">
-                <v-checkbox v-model="dialog.form.fmanualEntry" label="手工录入" />
-              </v-col>
-              <v-col cols="12" md="6" class="d-flex align-center">
-                <v-checkbox v-model="dialog.form.fcash" label="现金科目" />
-              </v-col>
-              <v-col cols="12" md="6" class="d-flex align-center">
-                <v-checkbox v-model="dialog.form.fbank" label="银行科目" />
-              </v-col>
-              <v-col cols="12" md="6" class="d-flex align-center">
-                <v-checkbox v-model="dialog.form.fequivalent" label="现金等价物" />
-              </v-col>
-              <v-col cols="12" md="6" class="d-flex align-center">
-                <v-checkbox v-model="dialog.form.fisEntry" label="登记记账" />
-              </v-col>
-              <v-col cols="12" md="6" class="d-flex align-center">
-                <v-checkbox v-model="dialog.form.fnotice" label="往来通知" />
-              </v-col>
-              <v-col cols="12" md="6" class="d-flex align-center">
-                <v-checkbox v-model="dialog.form.fexchange" label="期末调汇" />
-              </v-col>
-              <v-col cols="12" md="6" class="d-flex align-center">
-                <v-checkbox v-model="dialog.form.fqtyAccounting" label="数量核算" />
-              </v-col>
-            </v-row>
-          </v-form>
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn variant="text" @click="closeDialog">取消</v-btn>
-          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
 
     <v-dialog v-model="deleteDialog.visible" max-width="350">
       <v-card>
@@ -116,6 +34,7 @@
 
 <script setup>
 import { ref, reactive, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { useSimpleData } from '@/composables/base-data/useSimpleData'
 
 const fields = [
@@ -143,37 +62,14 @@ const controlLevelOptions = ref([])
 const reportItemOptions = ref([])
 const level1Options = ref([])
 
+const router = useRouter()
 const snackbar = reactive({ show: false, text: '', color: 'success' })
-const dialog = reactive({
-  visible: false,
-  mode: 'create',
-  form: Object.fromEntries(fields.map(k => [k, ''])),
-  valid: false,
-})
-const formRef = ref()
 
 function openCreateDialog() {
-  dialog.visible = true
-  dialog.mode = 'create'
-  Object.keys(dialog.form).forEach(k => dialog.form[k] = '')
+  router.push('/finance/base-data/account-subject/form')
 }
 function openEditDialog(item) {
-  dialog.visible = true
-  dialog.mode = 'edit'
-  Object.assign(dialog.form, item)
-}
-function closeDialog() { dialog.visible = false }
-async function handleConfirm() {
-  const valid = await formRef.value?.validate?.()
-  if (!valid) return
-  if (dialog.mode === 'create') {
-    await createItem({ ...dialog.form })
-    showMsg('创建成功')
-  } else {
-    await editItem({ ...dialog.form })
-    showMsg('保存成功')
-  }
-  closeDialog()
+  router.push(`/finance/base-data/account-subject/form/${item.fid}`)
 }
 const deleteDialog = reactive({ visible: false, item: null })
 function openDeleteDialog(item) { deleteDialog.visible = true; deleteDialog.item = item }

--- a/src/views/login/finance/base-data/account-subject/AccountSubjectForm.vue
+++ b/src/views/login/finance/base-data/account-subject/AccountSubjectForm.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="account-subject-form-page">
+    <h2 class="title">{{ isEdit ? '编辑科目' : '创建科目' }}</h2>
+    <v-form ref="formRef" v-model="valid">
+      <v-card class="mb-6" elevation="2">
+        <v-card-title>基本信息</v-card-title>
+        <v-card-text>
+          <v-row dense>
+            <v-col cols="12" md="6">
+              <v-text-field v-model="form.fcode" label="编码" :rules="[v=>!!v||'必填']" required />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-text-field v-model="form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-select v-model="form.forg" :items="orgOptions" label="核算组织" required />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-text-field v-model="form.flongName" label="长名称" />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-select v-model="form.ftype" :items="acctTypeOptions" label="科目类型" required />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-autocomplete v-model="form.fparent" :items="subjectOptions" label="上级" clearable />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-select v-model="form.fpltype" :items="profitLossOptions" label="损益类型" />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-select v-model="form.fdirection" :items="['借','贷']" label="余额方向" required />
+            </v-col>
+            <v-col cols="12" md="6" class="d-flex align-center">
+              <v-switch v-model="form.fisDetail" label="明细科目" />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-autocomplete v-model="form.freportItem" :items="reportItemOptions" label="报表项目" clearable />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-autocomplete v-model="form.flevel1" :items="level1Options" label="一级科目" clearable />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+
+      <v-card class="mb-6" elevation="2">
+        <v-card-title>控制信息</v-card-title>
+        <v-card-text>
+          <v-row dense>
+            <v-col cols="12" md="6">
+              <v-select v-model="form.fentryControl" :items="entryControlOptions" label="科目录入方向控制" required />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-select v-model="form.fcontrolLevel" :items="controlLevelOptions" label="控制级次" />
+            </v-col>
+            <v-col cols="12" md="6" class="d-flex align-center">
+              <v-switch v-model="form.fallowChild" label="允许公司增加下级科目" />
+            </v-col>
+            <v-col cols="12" md="6" class="d-flex align-center">
+              <v-switch v-model="form.fmanualEntry" label="手工录入" />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+
+      <v-card class="mb-6" elevation="2">
+        <v-card-title>科目属性</v-card-title>
+        <v-card-text>
+          <v-row dense>
+            <v-col cols="12" md="6" class="d-flex align-center">
+              <v-checkbox v-model="form.fcash" label="现金科目" />
+            </v-col>
+            <v-col cols="12" md="6" class="d-flex align-center">
+              <v-checkbox v-model="form.fbank" label="银行科目" />
+            </v-col>
+            <v-col cols="12" md="6" class="d-flex align-center">
+              <v-checkbox v-model="form.fequivalent" label="现金等价物" />
+            </v-col>
+            <v-col cols="12" md="6" class="d-flex align-center">
+              <v-checkbox v-model="form.fisEntry" label="登记记账" />
+            </v-col>
+            <v-col cols="12" md="6" class="d-flex align-center">
+              <v-checkbox v-model="form.fnotice" label="往来通知" />
+            </v-col>
+            <v-col cols="12" md="6" class="d-flex align-center">
+              <v-checkbox v-model="form.fexchange" label="期末调汇" />
+            </v-col>
+            <v-col cols="12" md="6" class="d-flex align-center">
+              <v-checkbox v-model="form.fqtyAccounting" label="数量核算" />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+
+      <div class="actions">
+        <v-btn color="primary" @click="handleSave">保存</v-btn>
+        <v-btn class="ml-3" @click="goBack">取消</v-btn>
+      </div>
+    </v-form>
+  </div>
+</template>
+
+<script setup>
+import { reactive, ref, onMounted, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import request from '@/utils/request'
+
+const route = useRoute()
+const router = useRouter()
+const fid = route.params.fid
+
+const fields = [
+  'fid','fcode','fname','forg','flongName','ftype','fparent','fpltype','fdirection','fisDetail',
+  'freportItem','flevel1','fentryControl','fcontrolLevel','fallowChild','fmanualEntry',
+  'fcash','fbank','fequivalent','fisEntry','fnotice','fexchange','fqtyAccounting',
+]
+
+const form = reactive(Object.fromEntries(fields.map(k => [k, ''])))
+const valid = ref(false)
+const formRef = ref()
+
+const orgOptions = ref([])
+const acctTypeOptions = ref(['资产','负债','权益','成本','损益'])
+const subjectOptions = ref([])
+const profitLossOptions = ref([])
+const entryControlOptions = ref(['借','贷','借或贷'])
+const controlLevelOptions = ref([])
+const reportItemOptions = ref([])
+const level1Options = ref([])
+
+const isEdit = computed(() => !!fid)
+
+async function fetchDetail() {
+  if (!fid) return
+  const res = await request.get(`/account-subject/${fid}`)
+  Object.assign(form, res.data || {})
+}
+
+async function handleSave() {
+  const ok = await formRef.value?.validate?.()
+  if (!ok) return
+  if (fid) {
+    await request.put('/account-subject', { ...form, fid })
+  } else {
+    const data = { ...form }
+    delete data.fid
+    await request.post('/account-subject', data)
+  }
+  router.push('/finance/base-data/account-subject')
+}
+
+function goBack() {
+  router.push('/finance/base-data/account-subject')
+}
+
+onMounted(() => {
+  fetchDetail()
+})
+</script>
+
+<style scoped>
+.account-subject-form-page { padding: 24px; }
+.title { font-size: 22px; font-weight: bold; color: #27324c; margin-bottom: 20px; }
+.actions { text-align: right; margin-top: 24px; }
+</style>
+


### PR DESCRIPTION
## Summary
- add a dedicated account subject form page
- route to the form page for new or edit actions
- remove dialog editing from the list page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686400e98778832f8580a8283ddf72a7