### PR TITLE
Centralize backend requests under src/api

### DIFF
--- a/src/api/accountSubject.js
+++ b/src/api/accountSubject.js
@@ -1,0 +1,21 @@
+import request from '@/utils/request'
+
+export function getAccountSubjectList(params = {}) {
+    return request.get('/account-subject/list', { params })
+}
+
+export function getAccountSubjectDetail(fid) {
+    return request.get(`/account-subject/${fid}`)
+}
+
+export function createAccountSubject(data) {
+    return request.post('/account-subject', data)
+}
+
+export function editAccountSubject(data) {
+    return request.put('/account-subject', data)
+}
+
+export function deleteAccountSubject(fid) {
+    return request.delete(`/account-subject/${fid}`)
+}

--- a/src/api/simpleData.js
+++ b/src/api/simpleData.js
@@ -1,0 +1,21 @@
+import request from '@/utils/request'
+
+export function fetchSimpleList(basePath, params = {}) {
+    return request.get(`${basePath}/list`, { params })
+}
+
+export function createSimpleData(basePath, data) {
+    return request.post(basePath, data)
+}
+
+export function editSimpleData(basePath, data) {
+    return request.put(basePath, data)
+}
+
+export function deleteSimpleData(basePath, fid) {
+    return request.delete(`${basePath}/${fid}`)
+}
+
+export function getSimpleDetail(basePath, fid) {
+    return request.get(`${basePath}/${fid}`)
+}

--- a/src/composables/base-data/useSimpleData.js
+++ b/src/composables/base-data/useSimpleData.js
@@ -1,5 +1,10 @@
 import { ref } from 'vue'
-import request from '@/utils/request'
+import {
+  fetchSimpleList,
+  createSimpleData,
+  editSimpleData,
+  deleteSimpleData,
+} from '@/api/simpleData'
 
 export function useSimpleData(basePath, fields = ['fid','fname','fcode']) {
   const list = ref([])
@@ -8,10 +13,10 @@ export function useSimpleData(basePath, fields = ['fid','fname','fcode']) {
   const fetchList = async () => {
     loading.value = true
     try {
-      const res = await request.get(`${basePath}/list`)
+      const res = await fetchSimpleList(basePath)
       list.value = (res.data?.records || []).map(i => ({
-        ...fields.reduce((a,k) => ({ ...a, [k]: '' }), {}),
-        ...i
+        ...fields.reduce((a, k) => ({ ...a, [k]: '' }), {}),
+        ...i,
       }))
     } finally {
       loading.value = false
@@ -21,17 +26,17 @@ export function useSimpleData(basePath, fields = ['fid','fname','fcode']) {
   const createItem = async (item) => {
     const data = { ...item }
     delete data.fid
-    await request.post(basePath, data)
+    await createSimpleData(basePath, data)
     await fetchList()
   }
 
   const editItem = async (item) => {
-    await request.put(basePath, item)
+    await editSimpleData(basePath, item)
     await fetchList()
   }
 
   const deleteItem = async (item) => {
-    await request.delete(`${basePath}/${item.fid}`)
+    await deleteSimpleData(basePath, item.fid)
     await fetchList()
   }
 

--- a/src/views/login/finance/base-data/account-subject/AccountSubjectForm.vue
+++ b/src/views/login/finance/base-data/account-subject/AccountSubjectForm.vue
@@ -103,7 +103,11 @@
 <script setup>
 import { reactive, ref, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import request from '@/utils/request'
+import {
+  getAccountSubjectDetail,
+  createAccountSubject,
+  editAccountSubject,
+} from '@/api/accountSubject'
 
 const route = useRoute()
 const router = useRouter()
@@ -132,7 +136,7 @@ const isEdit = computed(() => !!fid)
 
 async function fetchDetail() {
   if (!fid) return
-  const res = await request.get(`/account-subject/${fid}`)
+  const res = await getAccountSubjectDetail(fid)
   Object.assign(form, res.data || {})
 }
 
@@ -140,11 +144,11 @@ async function handleSave() {
   const ok = await formRef.value?.validate?.()
   if (!ok) return
   if (fid) {
-    await request.put('/account-subject', { ...form, fid })
+    await editAccountSubject({ ...form, fid })
   } else {
     const data = { ...form }
     delete data.fid
-    await request.post('/account-subject', data)
+    await createAccountSubject(data)
   }
   router.push('/finance/base-data/account-subject')
 }


### PR DESCRIPTION
## Summary
- create generic SimpleData API wrapper
- add AccountSubject API module
- refactor SimpleData composable to call the new API
- update AccountSubjectForm to use API functions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68654cbb2368832f9cf356d193c4f386