### PR TITLE
Add org function type page

### DIFF
--- a/src/api/orgFunctionType.js
+++ b/src/api/orgFunctionType.js
@@ -1,0 +1,28 @@
+import request from '@/utils/request'
+
+export function getOrgFunctionTypeList(params = {}) {
+  return request.get('/org-function-type/list', { params })
+}
+
+export function createOrgFunctionType(data) {
+  return request.post('/org-function-type', data)
+}
+
+export function editOrgFunctionType(data) {
+  return request.put('/org-function-type', data)
+}
+
+export function deleteOrgFunctionType(fid) {
+  return request.delete(`/org-function-type/${fid}`)
+}
+
+export function getOrgFunctionTypeDetail(fid) {
+  return request.get(`/org-function-type/${fid}`)
+}
+
+export default {
+  fetchList: getOrgFunctionTypeList,
+  createItem: createOrgFunctionType,
+  editItem: editOrgFunctionType,
+  deleteItem: deleteOrgFunctionType,
+}

--- a/src/composables/login/enterprise-modeling/org-function-type/useOrgFunctionType.js
+++ b/src/composables/login/enterprise-modeling/org-function-type/useOrgFunctionType.js
@@ -1,0 +1,41 @@
+import { ref } from 'vue'
+import { getOrgFunctionTypeList, createOrgFunctionType as createApi, editOrgFunctionType as editApi, deleteOrgFunctionType as deleteApi } from '@/api/orgFunctionType'
+
+const FIELDS = ['fid','fname','fnumber','ftype','fbasefunction','fcustom']
+
+export function useOrgFunctionType() {
+  const list = ref([])
+  const loading = ref(false)
+
+  const fetchList = async () => {
+    loading.value = true
+    try {
+      const res = await getOrgFunctionTypeList()
+      list.value = (res.data?.records || []).map(i => ({
+        ...FIELDS.reduce((a,k)=>({ ...a, [k]: '' }), {}),
+        ...i
+      }))
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const createItem = async (item) => {
+    const data = { ...item }
+    delete data.fid
+    await createApi(data)
+    await fetchList()
+  }
+
+  const editItem = async (item) => {
+    await editApi(item)
+    await fetchList()
+  }
+
+  const deleteItem = async (item) => {
+    await deleteApi(item.fid)
+    await fetchList()
+  }
+
+  return { list, loading, fetchList, createItem, editItem, deleteItem }
+}

--- a/src/composables/login/enterprise-modeling/useEnterpriseModeling.js
+++ b/src/composables/login/enterprise-modeling/useEnterpriseModeling.js
@@ -8,6 +8,7 @@ export function useEnterpriseModeling() {
                 { name: '人员', icon: '👤', path: '/personal' }, // 跳转人员管理
                 { name: '业务单元', icon: '🏢', path: '/business-unit' },
                 { name: '部门维度管理', icon: '🏬', path: '/department-dimension' },
+                { name: '组织职能类型', icon: '🧩', path: '/org-function-type' },
                 { name: '人员类型', icon: '👥' },
                 { name: '行政组织', icon: '🔗' }
             ]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,6 +6,7 @@ import EnterpriseModelingView from '../views/login/enterprise-modeling/Enterpris
 import PersonalView from '../views/login/enterprise-modeling/person/PersonalView.vue';
 import BusinessUnitView from '../views/login/enterprise-modeling/business-unit/BusinessUnitView.vue';
 import DeptDimensionView from '../views/login/enterprise-modeling/dept-dimension/DeptDimensionView.vue';
+import OrgFunctionTypeView from '../views/login/enterprise-modeling/org-function-type/OrgFunctionTypeView.vue';
 import BaseDataView from '../views/login/base-data/BaseDataView.vue';
 import MaterialView from '../views/login/base-data/material/MaterialView.vue';
 import CustomerView from '../views/login/base-data/customer/CustomerView.vue';
@@ -127,6 +128,12 @@ const routes = [
         name: 'DepartmentDimension',
         component: DeptDimensionView,
         meta: { title: '部门维度管理' }
+    },
+    {
+        path: '/org-function-type',
+        name: 'OrgFunctionType',
+        component: OrgFunctionTypeView,
+        meta: { title: '组织职能类型管理' }
     },
     { path: '/material', name: 'Material', component: MaterialView, meta: { title: '物料管理' } },
     { path: '/customer', name: 'Customer', component: CustomerView, meta: { title: '客户管理' } },

--- a/src/views/login/enterprise-modeling/org-function-type/OrgFunctionTypeView.vue
+++ b/src/views/login/enterprise-modeling/org-function-type/OrgFunctionTypeView.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="org-func-type-page">
+    <v-card elevation="4" class="pa-6">
+      <div class="header">
+        <h2 class="title">组织职能类型管理</h2>
+        <v-btn color="primary" @click="openCreateDialog" prepend-icon="mdi-plus">创建类型</v-btn>
+      </div>
+      <v-data-table :headers="headers" :items="list" :loading="loading" class="elevation-0" item-key="fid" hide-default-footer dense>
+        <template #item.ftype="{ item }">
+          <span>{{ item.ftype }}</span>
+        </template>
+        <template #item.fbasefunction="{ item }">
+          <v-chip size="small" :color="item.fbasefunction ? 'primary' : ''" variant="tonal">
+            {{ item.fbasefunction ? '是' : '否' }}
+          </v-chip>
+        </template>
+        <template #item.fcustom="{ item }">
+          <v-chip size="small" :color="item.fcustom ? 'primary' : ''" variant="tonal">
+            {{ item.fcustom ? '是' : '否' }}
+          </v-chip>
+        </template>
+        <template #item.actions="{ item }">
+          <v-btn size="small" color="primary" variant="tonal" @click="openEditDialog(item)">编辑</v-btn>
+          <v-btn size="small" color="error" variant="tonal" class="ml-1" @click="openDeleteDialog(item)">删除</v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="dialog.visible" max-width="500" persistent>
+      <v-card>
+        <v-card-title>{{ dialog.mode === 'create' ? '创建类型' : '编辑类型' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="dialog.valid">
+            <v-text-field v-model="dialog.form.fname" label="名称" :rules="[v=>!!v||'必填']" required />
+            <v-text-field v-model="dialog.form.fnumber" label="编码" />
+            <v-text-field v-model="dialog.form.ftype" label="类型" />
+            <v-switch v-model="dialog.form.fbasefunction" label="基本职能" true-value="1" false-value="0" />
+            <v-switch v-model="dialog.form.fcustom" label="自定义" true-value="1" false-value="0" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">取消</v-btn>
+          <v-btn variant="text" color="primary" @click="handleConfirm">{{ dialog.mode === 'create' ? '创建' : '保存' }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="350">
+      <v-card>
+        <v-card-title class="text-h6">确认删除</v-card-title>
+        <v-card-text>确认删除类型 <b>{{ deleteDialog.item?.fname }}</b>？</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
+          <v-btn variant="text" color="error" @click="handleDelete">确定</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+      {{ snackbar.text }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { useOrgFunctionType } from '@/composables/login/enterprise-modeling/org-function-type/useOrgFunctionType'
+
+const { list, loading, fetchList, createItem, editItem, deleteItem } = useOrgFunctionType()
+
+const headers = ref([
+  { title: '名称', value: 'fname', align: 'start' },
+  { title: '编码', value: 'fnumber' },
+  { title: '类型', value: 'ftype' },
+  { title: '基本职能', value: 'fbasefunction', sortable: false },
+  { title: '自定义', value: 'fcustom', sortable: false },
+  { title: '操作', value: 'actions', sortable: false, align: 'center', width: 150 },
+])
+
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const dialog = reactive({
+  visible: false,
+  mode: 'create',
+  form: { fid: null, fname: '', fnumber: '', ftype: '', fbasefunction: 0, fcustom: 0 },
+  valid: false,
+})
+const formRef = ref()
+
+function openCreateDialog() {
+  dialog.visible = true
+  dialog.mode = 'create'
+  Object.assign(dialog.form, { fid: null, fname: '', fnumber: '', ftype: '', fbasefunction: 0, fcustom: 0 })
+}
+function openEditDialog(item) {
+  dialog.visible = true
+  dialog.mode = 'edit'
+  Object.assign(dialog.form, { ...item })
+}
+function closeDialog() {
+  dialog.visible = false
+}
+async function handleConfirm() {
+  const valid = await formRef.value?.validate?.()
+  if (!valid) return
+  if (dialog.mode === 'create') {
+    await createItem({ ...dialog.form })
+    showMsg('创建成功')
+  } else {
+    await editItem({ ...dialog.form })
+    showMsg('保存成功')
+  }
+  closeDialog()
+}
+const deleteDialog = reactive({ visible: false, item: null })
+function openDeleteDialog(item) {
+  deleteDialog.visible = true
+  deleteDialog.item = item
+}
+async function handleDelete() {
+  await deleteItem(deleteDialog.item)
+  showMsg('删除成功')
+  deleteDialog.visible = false
+}
+function showMsg(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+
+onMounted(() => {
+  fetchList()
+})
+</script>
+
+<style scoped>
+.org-func-type-page { padding: 24px; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 22px; }
+.title { font-size: 22px; font-weight: bold; color: #27324c; letter-spacing: 2px; }
+</style>


### PR DESCRIPTION
## Summary
- support organization function type CRUD
- include API and composable utilities
- register new route and menu entry

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865f5358a70832f843c3535be47acab