### PR TITLE
feat(im): add realtime notification experience

### DIFF
--- a/.github/workflows/im-realtime-ci.yml
+++ b/.github/workflows/im-realtime-ci.yml
@@ -1,0 +1,18 @@
+name: IM Realtime Web CI
+on:
+  push:
+    branches: [dev]
+    paths: ['src/api/im.js','src/services/imRealtime.js','src/components/im/**','src/views/im/**','src/App.vue','src/main.js','vite.config.js','package.json','package-lock.json','.github/workflows/im-realtime-ci.yml']
+  pull_request:
+    paths: ['src/api/im.js','src/services/imRealtime.js','src/components/im/**','src/views/im/**','src/App.vue','src/main.js','vite.config.js','package.json','package-lock.json','.github/workflows/im-realtime-ci.yml']
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - run: npm run build

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,11 +2,13 @@
   <v-app>
     <router-view />
     <AiAssistantLauncher />
+    <NotificationCenterLauncher />
   </v-app>
 </template>
 
 <script setup>
 import AiAssistantLauncher from '@/components/ai/AiAssistantLauncher.vue'
+import NotificationCenterLauncher from '@/components/im/NotificationCenterLauncher.vue'
 </script>
 
 <style>

--- a/src/api/im.js
+++ b/src/api/im.js
@@ -1,0 +1,8 @@
+import request from '@/utils/request'
+
+function dataOf(response) { return response?.data ?? response }
+export async function listNotifications(params = {}) { return dataOf(await request.get('/im/notifications', { params })) }
+export async function getUnreadCount() { return dataOf(await request.get('/im/notifications/unread-count')) }
+export async function markNotificationRead(notificationId) { return dataOf(await request.post(`/im/notifications/${notificationId}/read`)) }
+export async function markAllNotificationsRead() { return dataOf(await request.post('/im/notifications/read-all')) }
+export async function syncNotificationEvents(afterVersion = 0, limit = 100) { return dataOf(await request.get('/im/sync', { params: { afterVersion, limit } })) }

--- a/src/components/im/NotificationCenterLauncher.vue
+++ b/src/components/im/NotificationCenterLauncher.vue
@@ -1,0 +1,39 @@
+<template>
+  <div v-if="authenticated" class="im-notification-launcher">
+    <v-menu v-model="menuOpen" :close-on-content-click="false" location="bottom end">
+      <template #activator="{ props }"><v-badge :content="displayUnread" :model-value="unreadCount > 0" color="error"><v-btn v-bind="props" icon="mdi-bell-outline" variant="elevated" color="primary" aria-label="消息通知" /></v-badge></template>
+      <v-card width="380" max-height="520">
+        <v-card-title class="d-flex align-center justify-space-between"><span>消息通知</span><v-btn v-if="unreadCount" size="small" variant="text" @click="markAllRead">全部已读</v-btn></v-card-title>
+        <v-divider />
+        <v-list v-if="notifications.length" lines="three" class="notification-list">
+          <template v-for="item in notifications" :key="item.id">
+            <v-list-item :class="{ unread: item.readStatus === 'UNREAD' }" @click="openNotification(item)"><template #prepend><v-icon :color="item.readStatus === 'UNREAD' ? 'primary' : undefined">mdi-message-alert-outline</v-icon></template><v-list-item-title>{{ item.title }}</v-list-item-title><v-list-item-subtitle>{{ item.content }}</v-list-item-subtitle><v-list-item-subtitle class="text-caption">{{ formatTime(item.createdTime) }}</v-list-item-subtitle></v-list-item><v-divider />
+          </template>
+        </v-list>
+        <v-card-text v-else class="text-center text-medium-emphasis py-8">暂无通知</v-card-text>
+        <v-card-actions><v-btn block variant="text" color="primary" @click="viewAll">查看全部消息</v-btn></v-card-actions>
+      </v-card>
+    </v-menu>
+    <v-snackbar v-model="snackbar.visible" :timeout="6000" location="top right"><strong>{{ snackbar.title }}</strong><div class="mt-1">{{ snackbar.content }}</div><template #actions><v-btn variant="text" @click="openNotification(snackbar.notification)">查看</v-btn></template></v-snackbar>
+  </div>
+</template>
+
+<script setup>
+import { computed,onBeforeUnmount,onMounted,reactive,ref,watch } from 'vue'
+import { useRoute,useRouter } from 'vue-router'
+import { getUnreadCount,listNotifications,markAllNotificationsRead,markNotificationRead } from '@/api/im'
+import { IM_EVENT_NAME,imRealtime } from '@/services/imRealtime'
+const route=useRoute(),router=useRouter(),menuOpen=ref(false),unreadCount=ref(0),notifications=ref([])
+const snackbar=reactive({visible:false,title:'',content:'',notification:null})
+const authenticated=computed(()=>Boolean(localStorage.getItem('token'))&&!['/','/login','/register'].includes(route.path))
+const displayUnread=computed(()=>unreadCount.value>99?'99+':String(unreadCount.value))
+async function refresh(){if(!authenticated.value)return;try{const [countResult,listResult]=await Promise.all([getUnreadCount(),listNotifications({page:1,size:8})]);unreadCount.value=Number(countResult?.count||0);notifications.value=listResult?.records||[]}catch{}}
+function handleRealtime(event){const message=event.detail;if(message?.eventType==='NOTIFICATION_CREATED'){const notification={...message.data,id:message.data?.notificationId||message.data?.id};notifications.value=[notification,...notifications.value.filter(item=>item.id!==notification.id)].slice(0,8);if(message.replayed){refresh();return}unreadCount.value+=1;snackbar.title=notification.title||'新消息';snackbar.content=notification.content||'';snackbar.notification=notification;snackbar.visible=true}else if(message?.eventType==='NOTIFICATION_READ'||message?.eventType==='NOTIFICATIONS_READ_ALL'){refresh()}}
+async function openNotification(notification){if(!notification)return;menuOpen.value=false;snackbar.visible=false;if(notification.readStatus==='UNREAD'||!notification.readStatus){try{await markNotificationRead(notification.id);imRealtime.sendReadAck(notification.id);notification.readStatus='READ';unreadCount.value=Math.max(0,unreadCount.value-1)}catch{}}if(notification.actionUrl?.startsWith('/'))router.push(notification.actionUrl)}
+async function markAllRead(){await markAllNotificationsRead();unreadCount.value=0;notifications.value=notifications.value.map(item=>({...item,readStatus:'READ'}))}
+function viewAll(){menuOpen.value=false;router.push('/notifications')}
+function formatTime(value){return value?new Date(value).toLocaleString():''}
+function activate(){if(authenticated.value){imRealtime.start();refresh()}else imRealtime.stop()}
+onMounted(()=>{window.addEventListener(IM_EVENT_NAME,handleRealtime);activate()});onBeforeUnmount(()=>{window.removeEventListener(IM_EVENT_NAME,handleRealtime);imRealtime.stop()});watch(()=>route.fullPath,activate)
+</script>
+<style scoped>.im-notification-launcher{position:fixed;top:18px;right:24px;z-index:2500}.notification-list{max-height:390px;overflow-y:auto}.unread{background:rgba(var(--v-theme-primary),.08)}</style>

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,13 @@ router.addRoute({
   meta: { title: 'Matrix 开放平台' },
 })
 
+router.addRoute({
+  path: '/notifications',
+  name: 'Notifications',
+  component: () => import('./views/im/NotificationsView.vue'),
+  meta: { title: '消息中心' },
+})
+
 const app = createApp(App)
 app.use(ElementPlus)
 app.use(vuetify)

--- a/src/services/imRealtime.js
+++ b/src/services/imRealtime.js
@@ -1,0 +1,51 @@
+import { syncNotificationEvents } from '@/api/im'
+
+const VERSION_KEY = 'matrix.im.lastVersion'
+const DEVICE_KEY = 'matrix.im.deviceId'
+const EVENT_NAME = 'matrix-im-event'
+
+function createDeviceId() {
+  if (window.crypto?.randomUUID) return window.crypto.randomUUID().replaceAll('-', '')
+  return `web-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+function getDeviceId() { let value = localStorage.getItem(DEVICE_KEY); if (!value) { value = createDeviceId(); localStorage.setItem(DEVICE_KEY, value) } return value }
+function websocketUrl(token) { const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'; const query = new URLSearchParams({ access_token: token, deviceId: getDeviceId(), clientType: 'WEB' }); return `${protocol}//${window.location.host}/api/im/ws?${query}` }
+
+class ImRealtimeClient {
+  constructor() { this.socket=null; this.stopped=true; this.reconnectTimer=null; this.heartbeatTimer=null; this.reconnectAttempt=0; this.syncing=null }
+  start() { const token=localStorage.getItem('token'); if(!token){this.stop();return} this.stopped=false; if(this.socket?.readyState===WebSocket.OPEN||this.socket?.readyState===WebSocket.CONNECTING)return; this.connect(token) }
+  stop() { this.stopped=true; clearTimeout(this.reconnectTimer); clearInterval(this.heartbeatTimer); this.reconnectTimer=null; this.heartbeatTimer=null; if(this.socket){this.socket.onclose=null;this.socket.close();this.socket=null} }
+  sendReadAck(notificationId) { this.send({eventType:'READ_ACK',notificationId}) }
+  async sync() { if(this.syncing)return this.syncing; this.syncing=this.runSync().finally(()=>{this.syncing=null}); return this.syncing }
+  connect(token) {
+    try {
+      const socket=new WebSocket(websocketUrl(token)); this.socket=socket
+      socket.onopen=()=>{this.reconnectAttempt=0;this.startHeartbeat()}
+      socket.onmessage=message=>this.handleMessage(message.data)
+      socket.onerror=()=>socket.close()
+      socket.onclose=()=>{clearInterval(this.heartbeatTimer);this.heartbeatTimer=null;if(!this.stopped)this.scheduleReconnect()}
+    } catch { this.scheduleReconnect() }
+  }
+  handleMessage(raw) { let event; try{event=JSON.parse(raw)}catch{return} if(event.eventType==='SYSTEM_CONNECTED'){this.sync();this.emit(event);return} if(event.eventType==='SYSTEM_PONG')return; this.processPersistedEvent(event) }
+  async processPersistedEvent(event,fromSync=false) {
+    const version=Number(event.version||0), current=this.lastVersion()
+    if(!fromSync&&version>current+1){await this.sync();if(version<=this.lastVersion())return}
+    if(version>0&&version<=this.lastVersion()){if(event.eventType==='NOTIFICATION_CREATED')this.sendDeliveryAck(event);return}
+    if(version>0)this.saveVersion(version)
+    this.emit({...event,replayed:fromSync})
+    if(event.eventType==='NOTIFICATION_CREATED')this.sendDeliveryAck(event)
+  }
+  async runSync() {
+    let afterVersion=this.lastVersion(),hasMore=true
+    while(hasMore&&!this.stopped){const response=await syncNotificationEvents(afterVersion,100);const events=response?.events??[];for(const event of events){await this.processPersistedEvent(event,true);afterVersion=Math.max(afterVersion,Number(event.version||0))}hasMore=Boolean(response?.hasMore)&&events.length>0;if(!events.length&&Number(response?.currentVersion||0)>afterVersion){afterVersion=Number(response.currentVersion);this.saveVersion(afterVersion)}}
+  }
+  sendDeliveryAck(event) { const notificationId=event?.data?.notificationId||event?.data?.id;if(!notificationId)return;this.send({eventType:'DELIVER_ACK',eventId:event.eventId,notificationId}) }
+  send(payload) { if(this.socket?.readyState!==WebSocket.OPEN)return false;this.socket.send(JSON.stringify(payload));return true }
+  startHeartbeat() { clearInterval(this.heartbeatTimer);this.heartbeatTimer=setInterval(()=>this.send({eventType:'SYSTEM_PING',lastVersion:this.lastVersion()}),25000) }
+  scheduleReconnect() { clearTimeout(this.reconnectTimer);const delays=[1000,2000,5000,10000,30000],delay=delays[Math.min(this.reconnectAttempt,delays.length-1)];this.reconnectAttempt+=1;this.reconnectTimer=setTimeout(()=>this.start(),delay) }
+  emit(event) { window.dispatchEvent(new CustomEvent(EVENT_NAME,{detail:event})) }
+  lastVersion() { return Number(localStorage.getItem(VERSION_KEY)||0) }
+  saveVersion(version) { localStorage.setItem(VERSION_KEY,String(version)) }
+}
+export const imRealtime=new ImRealtimeClient()
+export const IM_EVENT_NAME=EVENT_NAME

--- a/src/views/im/NotificationsView.vue
+++ b/src/views/im/NotificationsView.vue
@@ -1,0 +1,19 @@
+<template>
+  <v-container fluid class="pa-6"><v-card><v-card-title class="d-flex align-center flex-wrap ga-3"><v-btn icon="mdi-arrow-left" variant="text" @click="router.back()"/><span>消息中心</span><v-spacer/><v-select v-model="readStatus" :items="statusOptions" label="状态" density="compact" hide-details clearable style="max-width:180px" @update:model-value="load(1)"/><v-btn color="primary" variant="tonal" @click="markAllRead">全部已读</v-btn><v-btn icon="mdi-refresh" variant="text" @click="load(page)"/></v-card-title><v-divider/>
+    <v-list v-if="records.length" lines="three"><template v-for="item in records" :key="item.id"><v-list-item :class="{unread:item.readStatus==='UNREAD'}" @click="open(item)"><template #prepend><v-icon :color="item.readStatus==='UNREAD'?'primary':undefined">mdi-bell-ring-outline</v-icon></template><v-list-item-title class="font-weight-medium">{{ item.title }}</v-list-item-title><v-list-item-subtitle>{{ item.content }}</v-list-item-subtitle><v-list-item-subtitle class="text-caption">{{ item.messageType }} · {{ formatTime(item.createdTime) }}</v-list-item-subtitle><template #append><v-chip v-if="item.readStatus==='UNREAD'" size="small" color="primary">未读</v-chip></template></v-list-item><v-divider/></template></v-list>
+    <v-card-text v-else-if="!loading" class="text-center text-medium-emphasis py-12">暂无消息</v-card-text><v-progress-linear v-if="loading" indeterminate/><v-card-actions class="justify-center"><v-pagination v-model="page" :length="pageCount" @update:model-value="load"/></v-card-actions></v-card></v-container>
+</template>
+<script setup>
+import { computed,onMounted,ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { listNotifications,markAllNotificationsRead,markNotificationRead } from '@/api/im'
+import { imRealtime } from '@/services/imRealtime'
+const router=useRouter(),records=ref([]),total=ref(0),page=ref(1),readStatus=ref(null),loading=ref(false),size=20
+const statusOptions=[{title:'未读',value:'UNREAD'},{title:'已读',value:'READ'}],pageCount=computed(()=>Math.max(1,Math.ceil(total.value/size)))
+async function load(targetPage=1){loading.value=true;try{page.value=targetPage;const result=await listNotifications({page:targetPage,size,readStatus:readStatus.value||undefined});records.value=result?.records||[];total.value=Number(result?.total||0)}finally{loading.value=false}}
+async function open(item){if(item.readStatus==='UNREAD'){await markNotificationRead(item.id);imRealtime.sendReadAck(item.id);item.readStatus='READ'}if(item.actionUrl?.startsWith('/'))router.push(item.actionUrl)}
+async function markAllRead(){await markAllNotificationsRead();records.value=records.value.map(item=>({...item,readStatus:'READ'}));if(readStatus.value==='UNREAD')await load(1)}
+function formatTime(value){return value?new Date(value).toLocaleString():''}
+onMounted(()=>{imRealtime.start();load()})
+</script>
+<style scoped>.unread{background:rgba(var(--v-theme-primary),.06)}</style>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,22 +4,11 @@ import vuetify from 'vite-plugin-vuetify'
 import path from 'path'
 
 export default defineConfig({
-  plugins: [
-    vue(),
-    vuetify({ autoImport: true }),
-  ],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
+  plugins: [vue(), vuetify({ autoImport: true })],
+  resolve: { alias: { '@': path.resolve(__dirname, './src') } },
   server: {
     proxy: {
-      '/api': {
-        target: 'http://localhost:10000',
-        changeOrigin: true,
-        // rewrite: path => path.replace(/^\/api/, ''),
-      },
+      '/api': { target: 'http://localhost:10000', changeOrigin: true, ws: true },
     },
   },
 })


### PR DESCRIPTION
## Summary

- add a global notification bell with unread count and recent-message panel
- show real-time notification snackbar prompts without modifying individual business pages
- add a full `/notifications` message center with filtering, pagination, mark-read, and mark-all-read actions
- add a WebSocket client with heartbeat and bounded reconnect backoff
- persist a client sync version, detect event gaps, and recover missing events through `/api/im/sync`
- send delivery and read acknowledgements
- enable WebSocket forwarding in the Vite development proxy
- add a dedicated npm build workflow for the notification feature

## Reliability

Replayed reconnect events refresh state without displaying duplicate snackbars or incrementing unread counts twice. The REST notification list remains the authoritative UI state when the WebSocket is unavailable.

## Validation

- JavaScript syntax and Vue file structure checked before commit
- branch is based on the current frontend `dev` and preserves the Scheduler web CI workflow
- `npm ci` and `npm run build` will run in GitHub Actions
