### PR TITLE
feat: align workflow expense IM and portal frontend

### DIFF
--- a/.github/workflows/portal-ci.yml
+++ b/.github/workflows/portal-ci.yml
@@ -1,0 +1,44 @@
+name: Portal Web CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - 'src/views/login/Portal.vue'
+      - 'src/components/platform/**'
+      - 'src/api/platform.js'
+      - 'src/utils/matrixIcons.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/portal-ci.yml'
+  push:
+    branches:
+      - 'feature/application-center-*'
+    paths:
+      - 'src/views/login/Portal.vue'
+      - 'src/components/platform/**'
+      - 'src/api/platform.js'
+      - 'src/utils/matrixIcons.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/portal-ci.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build portal
+        run: npm run build

--- a/.github/workflows/workflow-expense-web-ci.yml
+++ b/.github/workflows/workflow-expense-web-ci.yml
@@ -1,0 +1,54 @@
+name: Workflow Expense Web CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - 'src/main.js'
+      - 'src/api/workflow.js'
+      - 'src/api/expense.js'
+      - 'src/api/imManagement.js'
+      - 'src/utils/currentUser.js'
+      - 'src/views/login/PlatformPortalView.vue'
+      - 'src/views/login/workflow/**'
+      - 'src/views/login/expense/**'
+      - 'src/views/im/ImManagementView.vue'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/workflow-expense-web-ci.yml'
+  push:
+    branches:
+      - 'feature/workflow-expense-*'
+    paths:
+      - 'src/main.js'
+      - 'src/api/workflow.js'
+      - 'src/api/expense.js'
+      - 'src/api/imManagement.js'
+      - 'src/utils/currentUser.js'
+      - 'src/views/login/PlatformPortalView.vue'
+      - 'src/views/login/workflow/**'
+      - 'src/views/login/expense/**'
+      - 'src/views/im/ImManagementView.vue'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/workflow-expense-web-ci.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build

--- a/src/api/expense.js
+++ b/src/api/expense.js
@@ -1,0 +1,34 @@
+import request from '@/utils/request'
+import { newRequestId } from '@/utils/currentUser'
+
+export function createExpense(data) {
+  return request.post('/fi/expense-reimbursements', data)
+}
+
+export function updateExpense(expenseId, data) {
+  return request.put(`/fi/expense-reimbursements/${encodeURIComponent(expenseId)}`, data)
+}
+
+export function getExpense(expenseId) {
+  return request.get(`/fi/expense-reimbursements/${encodeURIComponent(expenseId)}`)
+}
+
+export function getExpenseApprovalDetail(expenseId) {
+  return request.get(`/fi/expense-reimbursements/${encodeURIComponent(expenseId)}/approval-detail`)
+}
+
+export function submitExpense(expenseId, data) {
+  return request.post(
+    `/fi/expense-reimbursements/${encodeURIComponent(expenseId)}/submit`,
+    data,
+    { headers: { 'X-Request-Id': newRequestId('expense-submit') } }
+  )
+}
+
+export function cancelExpense(expenseId, data) {
+  return request.post(
+    `/fi/expense-reimbursements/${encodeURIComponent(expenseId)}/cancel`,
+    data,
+    { headers: { 'X-Request-Id': newRequestId('expense-cancel') } }
+  )
+}

--- a/src/api/imManagement.js
+++ b/src/api/imManagement.js
@@ -1,0 +1,21 @@
+import request from '@/utils/request'
+
+export function listImApplications() {
+  return request.get('/im/applications')
+}
+
+export function saveImApplication(data) {
+  return request.post('/im/applications', data)
+}
+
+export function rotateImApplicationSecret(appCode) {
+  return request.post(`/im/applications/${encodeURIComponent(appCode)}/rotate-secret`)
+}
+
+export function listImTemplates() {
+  return request.get('/im/templates')
+}
+
+export function saveImTemplate(data) {
+  return request.post('/im/templates', data)
+}

--- a/src/api/workflow.js
+++ b/src/api/workflow.js
@@ -1,0 +1,18 @@
+import request from '@/utils/request'
+import { newRequestId } from '@/utils/currentUser'
+
+export function listWorkflowTaskCenter(params) {
+  return request.get('/workflow/task-center', { params })
+}
+
+export function getWorkflowTask(taskId) {
+  return request.get(`/workflow/tasks/${encodeURIComponent(taskId)}`)
+}
+
+export function actOnWorkflowTask(taskId, data) {
+  return request.post(
+    `/workflow/tasks/${encodeURIComponent(taskId)}/actions`,
+    data,
+    { headers: { 'X-Request-Id': newRequestId('workflow-action') } }
+  )
+}

--- a/src/components/platform/ApplicationCenterPanel.vue
+++ b/src/components/platform/ApplicationCenterPanel.vue
@@ -1,0 +1,743 @@
+<template>
+  <section class="application-center">
+    <section class="center-hero">
+      <div>
+        <span class="eyebrow">MATRIX APPLICATION CENTER</span>
+        <h1>应用中心</h1>
+        <p>统一发现和进入 Matrix 已建设的业务系统、智能能力、平台服务与集成工具。</p>
+      </div>
+
+      <div class="catalog-stats" aria-label="应用中心统计">
+        <article>
+          <strong>{{ apps.length }}</strong>
+          <span>系统总数</span>
+        </article>
+        <article>
+          <strong>{{ availableCount }}</strong>
+          <span>可直接使用</span>
+        </article>
+        <article>
+          <strong>{{ categoryCount }}</strong>
+          <span>能力分类</span>
+        </article>
+      </div>
+    </section>
+
+    <section class="catalog-toolbar">
+      <label class="catalog-search">
+        <Search />
+        <input v-model.trim="keyword" type="search" placeholder="搜索系统、能力或关键词" />
+        <button v-if="keyword" type="button" aria-label="清空搜索" @click="keyword = ''">
+          <Close />
+        </button>
+      </label>
+
+      <div class="category-tabs" role="tablist" aria-label="应用分类">
+        <button
+          v-for="category in categories"
+          :key="category.key"
+          type="button"
+          :class="{ active: activeCategory === category.key }"
+          @click="activeCategory = category.key"
+        >
+          <component :is="category.icon" />
+          <span>{{ category.label }}</span>
+          <small>{{ countByCategory(category.key) }}</small>
+        </button>
+      </div>
+    </section>
+
+    <section v-if="featuredApps.length && activeCategory === 'all' && !keyword" class="featured-section">
+      <div class="section-heading">
+        <div>
+          <span>FEATURED</span>
+          <h2>核心系统</h2>
+        </div>
+        <p>高频业务系统与平台核心入口</p>
+      </div>
+
+      <div class="featured-grid">
+        <article
+          v-for="app in featuredApps"
+          :key="app.key || app.name"
+          class="featured-card"
+          :style="{ '--accent': app.accent || '#2f7f6b' }"
+          @click="openApp(app)"
+        >
+          <div class="featured-icon">
+            <component :is="app.icon" />
+          </div>
+          <div class="featured-copy">
+            <div class="card-title-row">
+              <h3>{{ app.name }}</h3>
+              <span class="status-pill" :class="statusClass(app)">{{ displayStatus(app) }}</span>
+            </div>
+            <p>{{ app.desc }}</p>
+            <div class="tag-row">
+              <span v-for="tag in app.tags || []" :key="tag">{{ tag }}</span>
+            </div>
+          </div>
+          <ArrowRight class="featured-arrow" />
+        </article>
+      </div>
+    </section>
+
+    <section class="all-apps-section">
+      <div class="section-heading">
+        <div>
+          <span>CATALOG</span>
+          <h2>{{ currentCategoryLabel }}</h2>
+        </div>
+        <p>共 {{ filteredApps.length }} 个系统</p>
+      </div>
+
+      <div v-if="filteredApps.length" class="app-grid">
+        <article
+          v-for="app in filteredApps"
+          :key="app.key || app.name"
+          class="app-card"
+          :class="{ disabled: app.available === false }"
+          :style="{ '--accent': app.accent || '#2f7f6b' }"
+          @click="openApp(app)"
+        >
+          <div class="app-card-head">
+            <span class="app-icon">
+              <component :is="app.icon" />
+            </span>
+            <span class="status-pill" :class="statusClass(app)">{{ displayStatus(app) }}</span>
+          </div>
+
+          <div class="app-copy">
+            <span class="app-category">{{ categoryLabel(app.category) }}</span>
+            <h3>{{ app.name }}</h3>
+            <p>{{ app.desc }}</p>
+          </div>
+
+          <div class="tag-row compact">
+            <span v-for="tag in app.tags || []" :key="tag">{{ tag }}</span>
+          </div>
+
+          <div class="app-card-foot">
+            <span>{{ app.meta || 'Matrix 平台应用' }}</span>
+            <span class="open-link">
+              {{ app.available === false ? '查看规划' : '进入系统' }}
+              <ArrowRight />
+            </span>
+          </div>
+        </article>
+      </div>
+
+      <div v-else class="empty-catalog">
+        <Search />
+        <strong>没有匹配的系统</strong>
+        <p>尝试调整搜索词或切换其他分类。</p>
+        <button type="button" @click="resetFilter">查看全部应用</button>
+      </div>
+    </section>
+  </section>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import {
+  ArrowRight,
+  Close,
+  Connection,
+  Cpu,
+  Grid,
+  Monitor,
+  Search,
+} from '@element-plus/icons-vue'
+
+const props = defineProps({
+  apps: { type: Array, default: () => [] },
+})
+
+const emit = defineEmits(['open'])
+
+const keyword = ref('')
+const activeCategory = ref('all')
+
+const categories = [
+  { key: 'all', label: '全部应用', icon: Grid },
+  { key: 'business', label: '业务系统', icon: Monitor },
+  { key: 'intelligence', label: '智能系统', icon: Cpu },
+  { key: 'platform', label: '平台服务', icon: Grid },
+  { key: 'integration', label: '集成工具', icon: Connection },
+]
+
+const normalizedKeyword = computed(() => keyword.value.toLowerCase())
+
+const filteredApps = computed(() => {
+  return props.apps.filter((app) => {
+    const categoryMatched = activeCategory.value === 'all' || app.category === activeCategory.value
+    if (!categoryMatched) {
+      return false
+    }
+
+    if (!normalizedKeyword.value) {
+      return true
+    }
+
+    const text = [
+      app.name,
+      app.desc,
+      app.meta,
+      app.category,
+      ...(app.tags || []),
+    ].filter(Boolean).join(' ').toLowerCase()
+    return text.includes(normalizedKeyword.value)
+  })
+})
+
+const featuredApps = computed(() => props.apps.filter((app) => app.featured).slice(0, 3))
+const availableCount = computed(() => props.apps.filter((app) => app.available !== false).length)
+const categoryCount = computed(() => new Set(props.apps.map((app) => app.category).filter(Boolean)).size)
+const currentCategoryLabel = computed(() => {
+  return categories.find((item) => item.key === activeCategory.value)?.label || '全部应用'
+})
+
+function countByCategory(category) {
+  if (category === 'all') {
+    return props.apps.length
+  }
+  return props.apps.filter((app) => app.category === category).length
+}
+
+function categoryLabel(category) {
+  return categories.find((item) => item.key === category)?.label || '平台应用'
+}
+
+function displayStatus(app) {
+  if (app.status) {
+    return app.status
+  }
+  return app.available === false ? '规划中' : '已上线'
+}
+
+function statusClass(app) {
+  const status = displayStatus(app)
+  if (app.available === false || status.includes('规划')) {
+    return 'planned'
+  }
+  if (status.includes('试运行') || status.includes('内测')) {
+    return 'preview'
+  }
+  return 'live'
+}
+
+function openApp(app) {
+  emit('open', app)
+}
+
+function resetFilter() {
+  keyword.value = ''
+  activeCategory.value = 'all'
+}
+</script>
+
+<style scoped>
+.application-center {
+  display: grid;
+  gap: 24px;
+}
+
+.center-hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  padding: 34px 36px;
+  border: 1px solid #dce9e5;
+  border-radius: 28px;
+  background:
+    radial-gradient(circle at 88% 20%, rgba(61, 154, 126, 0.15), transparent 34%),
+    linear-gradient(135deg, #f7fffc 0%, #edf8f4 55%, #e4f3ee 100%);
+  box-shadow: 0 18px 44px rgba(38, 70, 68, 0.08);
+}
+
+.eyebrow,
+.section-heading span {
+  display: block;
+  margin-bottom: 8px;
+  color: #2f7f6b;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+}
+
+.center-hero h1 {
+  margin: 0;
+  color: #16312e;
+  font-size: clamp(30px, 3vw, 46px);
+}
+
+.center-hero p {
+  max-width: 680px;
+  margin: 14px 0 0;
+  color: #617672;
+  font-size: 15px;
+  line-height: 1.75;
+}
+
+.catalog-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(96px, 1fr));
+  gap: 10px;
+  min-width: 350px;
+}
+
+.catalog-stats article {
+  padding: 16px;
+  border: 1px solid rgba(47, 127, 107, 0.14);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.74);
+  text-align: center;
+}
+
+.catalog-stats strong,
+.catalog-stats span {
+  display: block;
+}
+
+.catalog-stats strong {
+  color: #1e6554;
+  font-size: 25px;
+}
+
+.catalog-stats span {
+  margin-top: 5px;
+  color: #72837f;
+  font-size: 12px;
+}
+
+.catalog-toolbar {
+  display: grid;
+  grid-template-columns: minmax(280px, 420px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid #e2ece9;
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 10px 28px rgba(38, 70, 68, 0.05);
+}
+
+.catalog-search {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) 28px;
+  gap: 10px;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid #dbe8e4;
+  border-radius: 13px;
+  color: #638078;
+  background: #f8fbfa;
+}
+
+.catalog-search > svg,
+.catalog-search button svg {
+  width: 18px;
+  height: 18px;
+}
+
+.catalog-search input {
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  color: #203532;
+  background: transparent;
+  font: inherit;
+}
+
+.catalog-search button {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  color: #7a8b87;
+  background: transparent;
+  cursor: pointer;
+}
+
+.category-tabs {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  overflow-x: auto;
+}
+
+.category-tabs button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 7px;
+  min-height: 40px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  color: #657975;
+  background: transparent;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.category-tabs button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.category-tabs button small {
+  display: grid;
+  min-width: 20px;
+  height: 20px;
+  place-items: center;
+  border-radius: 999px;
+  color: #71817e;
+  background: #edf3f1;
+}
+
+.category-tabs button.active {
+  border-color: #b9d9cf;
+  color: #1f6956;
+  background: #edf8f4;
+}
+
+.featured-section,
+.all-apps-section {
+  display: grid;
+  gap: 16px;
+}
+
+.section-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  color: #172c29;
+  font-size: 22px;
+}
+
+.section-heading p {
+  margin: 0;
+  color: #82918e;
+  font-size: 13px;
+}
+
+.featured-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.featured-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 58px minmax(0, 1fr) 22px;
+  gap: 16px;
+  align-items: start;
+  min-height: 190px;
+  padding: 24px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, #dce8e4);
+  border-radius: 22px;
+  background:
+    linear-gradient(145deg, color-mix(in srgb, var(--accent) 8%, white), white 66%);
+  box-shadow: 0 14px 34px rgba(38, 70, 68, 0.07);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.featured-card::after {
+  position: absolute;
+  right: -34px;
+  bottom: -46px;
+  width: 128px;
+  height: 128px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  content: '';
+}
+
+.featured-card:hover,
+.app-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 42px rgba(38, 70, 68, 0.12);
+}
+
+.featured-icon,
+.app-icon {
+  display: grid;
+  place-items: center;
+  color: #ffffff;
+  background: var(--accent);
+  box-shadow: 0 10px 22px color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+.featured-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 17px;
+}
+
+.featured-icon svg {
+  width: 27px;
+  height: 27px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.featured-copy h3,
+.app-copy h3 {
+  margin: 0;
+  color: #18312d;
+}
+
+.featured-copy h3 {
+  font-size: 20px;
+}
+
+.featured-copy p,
+.app-copy p {
+  color: #6f807c;
+  line-height: 1.7;
+}
+
+.featured-copy p {
+  margin: 12px 0 18px;
+  font-size: 13px;
+}
+
+.featured-arrow {
+  width: 20px;
+  height: 20px;
+  margin-top: 4px;
+  color: var(--accent);
+}
+
+.status-pill {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.status-pill.live {
+  color: #1f755c;
+  background: #def4eb;
+}
+
+.status-pill.preview {
+  color: #8b621d;
+  background: #fff1d2;
+}
+
+.status-pill.planned {
+  color: #7b8180;
+  background: #edf0ef;
+}
+
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.tag-row span {
+  padding: 5px 9px;
+  border-radius: 999px;
+  color: #55736b;
+  background: rgba(255, 255, 255, 0.7);
+  font-size: 11px;
+}
+
+.tag-row.compact span {
+  background: #f0f5f3;
+}
+
+.app-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.app-card {
+  display: flex;
+  min-height: 270px;
+  flex-direction: column;
+  padding: 22px;
+  border: 1px solid #e0eae7;
+  border-radius: 20px;
+  background: #ffffff;
+  box-shadow: 0 12px 30px rgba(38, 70, 68, 0.06);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-card.disabled {
+  cursor: default;
+  opacity: 0.72;
+}
+
+.app-card-head,
+.app-card-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.app-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 15px;
+}
+
+.app-icon svg {
+  width: 23px;
+  height: 23px;
+}
+
+.app-copy {
+  margin-top: 20px;
+}
+
+.app-category {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.app-copy h3 {
+  font-size: 18px;
+}
+
+.app-copy p {
+  min-height: 66px;
+  margin: 10px 0 16px;
+  font-size: 13px;
+}
+
+.app-card-foot {
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid #edf2f0;
+  color: #81908d;
+  font-size: 12px;
+}
+
+.open-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.open-link svg {
+  width: 15px;
+  height: 15px;
+}
+
+.empty-catalog {
+  display: grid;
+  justify-items: center;
+  padding: 64px 24px;
+  border: 1px dashed #cddbd7;
+  border-radius: 22px;
+  color: #748681;
+  background: #f9fbfa;
+  text-align: center;
+}
+
+.empty-catalog > svg {
+  width: 34px;
+  height: 34px;
+  margin-bottom: 14px;
+  color: #7fa297;
+}
+
+.empty-catalog strong {
+  color: #304743;
+  font-size: 17px;
+}
+
+.empty-catalog p {
+  margin: 8px 0 18px;
+}
+
+.empty-catalog button {
+  min-height: 38px;
+  padding: 0 16px;
+  border: 0;
+  border-radius: 10px;
+  color: #ffffff;
+  background: #2f7f6b;
+  cursor: pointer;
+}
+
+@media (max-width: 1180px) {
+  .center-hero,
+  .catalog-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .center-hero {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .category-tabs {
+    justify-content: flex-start;
+  }
+
+  .featured-grid,
+  .app-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .center-hero {
+    padding: 24px;
+  }
+
+  .catalog-stats {
+    min-width: 0;
+    width: 100%;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .featured-grid,
+  .app-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .featured-card {
+    grid-template-columns: 52px minmax(0, 1fr);
+  }
+
+  .featured-arrow {
+    display: none;
+  }
+}
+</style>

--- a/src/components/platform/WorkbenchPanel.vue
+++ b/src/components/platform/WorkbenchPanel.vue
@@ -1,0 +1,497 @@
+<template>
+  <section class="workbench-panel">
+    <section class="workbench-hero">
+      <div class="hero-copy">
+        <span class="eyebrow">PERSONAL WORKBENCH</span>
+        <h1>早上好，欢迎回到 Matrix</h1>
+        <p>工作台聚焦你今天需要处理的事项、关键指标和最近工作，不再承担完整应用导航。</p>
+        <div class="hero-actions">
+          <button type="button" class="primary-button" @click="$emit('open-app-center')">
+            <Grid class="button-icon" />
+            打开应用中心
+          </button>
+          <button type="button" class="secondary-button" @click="$emit('navigate', '/ai/assistant')">
+            <ChatDotRound class="button-icon" />
+            询问 AI 助手
+          </button>
+        </div>
+      </div>
+
+      <div class="metric-grid" aria-label="工作台关键指标">
+        <article v-for="metric in heroMetrics" :key="metric.label" class="metric-card">
+          <span>{{ metric.label }}</span>
+          <strong>{{ metric.value }}</strong>
+          <small>{{ metric.hint }}</small>
+        </article>
+      </div>
+    </section>
+
+    <section class="workbench-grid">
+      <div class="main-column">
+        <section class="panel-card todo-panel">
+          <div class="section-heading">
+            <div>
+              <span>TODAY</span>
+              <h2>我的待办</h2>
+            </div>
+            <button type="button" class="icon-button" title="刷新待办" @click="$emit('refresh')">
+              <Refresh />
+            </button>
+          </div>
+
+          <div v-if="todos.length" class="todo-list">
+            <button
+              v-for="todo in todos"
+              :key="todo.title"
+              type="button"
+              class="todo-item"
+              @click="$emit('navigate', todo.path)"
+            >
+              <span class="priority-dot" :class="todo.priority || 'low'"></span>
+              <div>
+                <strong>{{ todo.title }}</strong>
+                <small>{{ todo.desc }}</small>
+              </div>
+              <Clock class="row-icon" />
+            </button>
+          </div>
+          <div v-else class="empty-state">今天没有待处理事项。</div>
+        </section>
+
+        <section class="panel-card">
+          <div class="section-heading">
+            <div>
+              <span>RECENT</span>
+              <h2>最近访问</h2>
+            </div>
+          </div>
+
+          <div class="recent-list">
+            <button
+              v-for="item in recentItems"
+              :key="item.title"
+              type="button"
+              class="recent-item"
+              @click="$emit('navigate', item.path)"
+            >
+              <span class="recent-icon-wrap">
+                <component :is="item.icon" class="dynamic-icon" />
+              </span>
+              <div>
+                <strong>{{ item.title }}</strong>
+                <small>{{ item.detail }}</small>
+              </div>
+              <span class="recent-time">{{ item.time }}</span>
+              <ArrowRight class="row-icon" />
+            </button>
+          </div>
+        </section>
+      </div>
+
+      <aside class="side-column">
+        <section class="panel-card">
+          <div class="section-heading">
+            <div>
+              <span>QUICK ACTIONS</span>
+              <h2>快捷操作</h2>
+            </div>
+          </div>
+
+          <div class="quick-grid">
+            <button
+              v-for="action in quickActions"
+              :key="action.label"
+              type="button"
+              @click="$emit('navigate', action.path)"
+            >
+              <component :is="action.icon" class="dynamic-icon" />
+              <span>{{ action.label }}</span>
+            </button>
+          </div>
+        </section>
+
+        <section class="panel-card">
+          <div class="section-heading">
+            <div>
+              <span>NOTICE</span>
+              <h2>通知动态</h2>
+            </div>
+          </div>
+
+          <div class="notice-list">
+            <article v-for="notice in notices" :key="notice.title" class="notice-item">
+              <span class="notice-tag" :class="notice.type || 'platform'">{{ notice.tag }}</span>
+              <div>
+                <strong>{{ notice.title }}</strong>
+                <p>{{ notice.desc }}</p>
+              </div>
+            </article>
+          </div>
+        </section>
+      </aside>
+    </section>
+  </section>
+</template>
+
+<script setup>
+import { ArrowRight, ChatDotRound, Clock, Grid, Refresh } from '@element-plus/icons-vue'
+
+defineProps({
+  heroMetrics: { type: Array, default: () => [] },
+  todos: { type: Array, default: () => [] },
+  recentItems: { type: Array, default: () => [] },
+  notices: { type: Array, default: () => [] },
+  quickActions: { type: Array, default: () => [] },
+})
+
+defineEmits(['navigate', 'open-app-center', 'refresh'])
+</script>
+
+<style scoped>
+.workbench-panel {
+  display: grid;
+  gap: 24px;
+}
+
+.workbench-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(360px, 0.85fr);
+  gap: 28px;
+  padding: 36px;
+  border-radius: 28px;
+  color: #f7fffc;
+  background:
+    radial-gradient(circle at 88% 12%, rgba(83, 211, 167, 0.28), transparent 34%),
+    linear-gradient(135deg, #102b2c 0%, #174f49 58%, #1d6d5d 100%);
+  box-shadow: 0 22px 50px rgba(20, 65, 61, 0.18);
+}
+
+.hero-copy {
+  align-self: center;
+}
+
+.eyebrow,
+.section-heading span {
+  display: block;
+  margin-bottom: 8px;
+  color: #2f7f6b;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+}
+
+.hero-copy .eyebrow {
+  color: #9be4cf;
+}
+
+.hero-copy h1 {
+  margin: 0;
+  max-width: 620px;
+  font-size: clamp(28px, 3vw, 44px);
+  line-height: 1.15;
+}
+
+.hero-copy p {
+  max-width: 650px;
+  margin: 16px 0 0;
+  color: rgba(240, 255, 251, 0.76);
+  font-size: 15px;
+  line-height: 1.8;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 26px;
+}
+
+.hero-actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 42px;
+  padding: 0 18px;
+  border: 0;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.primary-button {
+  color: #15483f;
+  background: #e8fff7;
+}
+
+.secondary-button {
+  color: #f1fffb;
+  background: rgba(255, 255, 255, 0.11);
+  outline: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.button-icon,
+.dynamic-icon,
+.row-icon,
+.icon-button svg {
+  width: 18px;
+  height: 18px;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  align-content: center;
+}
+
+.metric-card {
+  min-height: 122px;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
+}
+
+.metric-card:first-child {
+  grid-column: 1 / -1;
+}
+
+.metric-card span,
+.metric-card small {
+  display: block;
+  color: rgba(241, 255, 251, 0.7);
+}
+
+.metric-card strong {
+  display: block;
+  margin: 8px 0 6px;
+  font-size: 30px;
+}
+
+.workbench-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.7fr);
+  gap: 24px;
+}
+
+.main-column,
+.side-column {
+  display: grid;
+  align-content: start;
+  gap: 24px;
+}
+
+.panel-card {
+  padding: 24px;
+  border: 1px solid #e4ece9;
+  border-radius: 22px;
+  background: #ffffff;
+  box-shadow: 0 14px 34px rgba(38, 70, 68, 0.07);
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  color: #17282b;
+  font-size: 20px;
+}
+
+.icon-button {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid #dce8e4;
+  border-radius: 10px;
+  color: #2d7563;
+  background: #f6fbf9;
+  cursor: pointer;
+}
+
+.todo-list,
+.recent-list,
+.notice-list {
+  display: grid;
+  gap: 10px;
+}
+
+.todo-item,
+.recent-item {
+  display: grid;
+  width: 100%;
+  align-items: center;
+  border: 0;
+  border-radius: 14px;
+  color: inherit;
+  background: #f8fbfa;
+  cursor: pointer;
+  text-align: left;
+  transition: transform 0.18s ease, background 0.18s ease;
+}
+
+.todo-item {
+  grid-template-columns: 10px minmax(0, 1fr) 20px;
+  gap: 14px;
+  padding: 16px;
+}
+
+.todo-item:hover,
+.recent-item:hover {
+  transform: translateY(-1px);
+  background: #f0f8f5;
+}
+
+.todo-item strong,
+.todo-item small,
+.recent-item strong,
+.recent-item small {
+  display: block;
+}
+
+.todo-item small,
+.recent-item small {
+  margin-top: 5px;
+  color: #748482;
+}
+
+.priority-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #79a69a;
+}
+
+.priority-dot.high { background: #df5f59; }
+.priority-dot.medium { background: #d79b31; }
+.priority-dot.low { background: #4f9a83; }
+
+.row-icon {
+  color: #8da09d;
+}
+
+.recent-item {
+  grid-template-columns: 42px minmax(0, 1fr) auto 18px;
+  gap: 12px;
+  padding: 13px 14px;
+}
+
+.recent-icon-wrap {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border-radius: 12px;
+  color: #2f7f6b;
+  background: #e9f6f1;
+}
+
+.recent-time {
+  color: #8b9997;
+  font-size: 12px;
+}
+
+.quick-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.quick-grid button {
+  display: flex;
+  min-height: 74px;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 14px;
+  border: 1px solid #e2ece9;
+  border-radius: 14px;
+  color: #294642;
+  background: #fbfdfc;
+  cursor: pointer;
+  text-align: left;
+}
+
+.quick-grid button:hover {
+  border-color: #9dc8bb;
+  background: #f2faf7;
+}
+
+.notice-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid #edf2f0;
+}
+
+.notice-item:last-child {
+  border-bottom: 0;
+}
+
+.notice-item strong {
+  color: #213633;
+  font-size: 14px;
+}
+
+.notice-item p {
+  margin: 5px 0 0;
+  color: #748482;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.notice-tag {
+  height: fit-content;
+  padding: 4px 8px;
+  border-radius: 999px;
+  color: #245f50;
+  background: #e6f5ef;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.notice-tag.finance { color: #8a5a17; background: #fff3d8; }
+.notice-tag.knowledge { color: #315f91; background: #e8f1fb; }
+.notice-tag.platform { color: #5b4d89; background: #f0ecfb; }
+
+.empty-state {
+  padding: 28px;
+  border-radius: 14px;
+  color: #81908d;
+  background: #f8fbfa;
+  text-align: center;
+}
+
+@media (max-width: 1100px) {
+  .workbench-hero,
+  .workbench-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 680px) {
+  .workbench-hero {
+    padding: 24px;
+  }
+
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-card:first-child {
+    grid-column: auto;
+  }
+
+  .quick-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,14 @@ import vuetify from './plugins/vuetify'
 import router from './router'
 import { initAuth } from './utils/auth'
 
+router.removeRoute('Portal')
+router.addRoute({
+  path: '/portal',
+  name: 'Portal',
+  component: () => import('./views/login/PlatformPortalView.vue'),
+  meta: { title: '个人工作台' },
+})
+
 router.addRoute({
   path: '/scheduler/jobs',
   name: 'SchedulerJobs',

--- a/src/main.js
+++ b/src/main.js
@@ -57,6 +57,45 @@ router.addRoute({
   meta: { title: '消息中心' },
 })
 
+router.addRoute({
+  path: '/workflow/tasks',
+  name: 'WorkflowTaskCenter',
+  component: () => import('./views/login/workflow/WorkflowTaskCenterView.vue'),
+  meta: { title: '工作流任务中心' },
+})
+
+router.addRoute({
+  path: '/expense-reimbursements',
+  name: 'ExpenseReimbursements',
+  component: () => import('./views/login/expense/ExpenseReimbursementView.vue'),
+  meta: { title: '费用报销' },
+})
+
+router.addRoute({
+  path: '/im/management',
+  name: 'ImManagement',
+  component: () => import('./views/im/ImManagementView.vue'),
+  meta: { title: 'IM 推送平台' },
+})
+
+const legacyRedirects = new Map([
+  ['/expenses', '/expense-reimbursements'],
+  ['/cost', '/expense-reimbursements'],
+  ['/workbench', '/workflow/tasks'],
+  ['/reports', '/ledger/balance-sheet'],
+  ['/estimated-payable', '/payable/estimate'],
+  ['/payment-application', '/payable/application'],
+  ['/payment-processing', '/payable/processing'],
+  ['/estimated-receivable', '/receivable/estimate'],
+  ['/settlement-processing', '/receivable/settlement'],
+])
+
+router.beforeEach(to => {
+  const target = legacyRedirects.get(to.path)
+  if (!target) return true
+  return { path: target, query: to.query, hash: to.hash, replace: true }
+})
+
 const app = createApp(App)
 app.use(ElementPlus)
 app.use(vuetify)

--- a/src/utils/currentUser.js
+++ b/src/utils/currentUser.js
@@ -1,0 +1,38 @@
+function decodeBase64Url(value) {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padding = '='.repeat((4 - (normalized.length % 4)) % 4)
+  return decodeURIComponent(
+    atob(normalized + padding)
+      .split('')
+      .map(char => `%${char.charCodeAt(0).toString(16).padStart(2, '0')}`)
+      .join('')
+  )
+}
+
+export function getCurrentUserId() {
+  const stored = localStorage.getItem('userId') || localStorage.getItem('username')
+  if (stored) return stored
+
+  const token = localStorage.getItem('token')
+  if (!token || token.split('.').length < 2) return ''
+
+  try {
+    const payload = JSON.parse(decodeBase64Url(token.split('.')[1]))
+    return payload.userId
+      || payload.user_id
+      || payload.sub
+      || payload.username
+      || payload.preferred_username
+      || ''
+  } catch (error) {
+    console.warn('Unable to resolve current user from JWT', error)
+    return ''
+  }
+}
+
+export function newRequestId(prefix = 'web') {
+  const id = typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`
+  return `${prefix}-${id}`
+}

--- a/src/views/im/ImManagementView.vue
+++ b/src/views/im/ImManagementView.vue
@@ -1,0 +1,336 @@
+<template>
+  <main class="im-page">
+    <section class="hero">
+      <div>
+        <span>IM MANAGEMENT</span>
+        <h1>IM 推送平台</h1>
+        <p>管理接入应用、调用密钥、渠道权限与消息模板。</p>
+      </div>
+      <div class="hero-actions">
+        <v-btn variant="tonal" prepend-icon="mdi-bell-outline" @click="router.push('/notifications')">个人消息中心</v-btn>
+        <v-btn color="primary" prepend-icon="mdi-refresh" :loading="loading" @click="refreshAll">刷新</v-btn>
+      </div>
+    </section>
+
+    <v-card class="workspace" elevation="0">
+      <v-tabs v-model="activeTab" color="primary">
+        <v-tab value="applications">接入应用</v-tab>
+        <v-tab value="templates">消息模板</v-tab>
+      </v-tabs>
+      <v-divider />
+
+      <v-window v-model="activeTab">
+        <v-window-item value="applications">
+          <div class="section-heading">
+            <div><span>APPLICATIONS</span><strong>接入应用</strong></div>
+            <v-btn color="primary" prepend-icon="mdi-plus" @click="openApplication()">新增应用</v-btn>
+          </div>
+          <v-data-table
+            :headers="applicationHeaders"
+            :items="applications"
+            :loading="loading"
+            item-value="appCode"
+            hide-default-footer
+            :items-per-page="-1"
+          >
+            <template #item.application="{ item }">
+              <div class="primary-cell"><strong>{{ item.appName }}</strong><small>{{ item.appCode }}</small></div>
+            </template>
+            <template #item.channels="{ item }">
+              <div class="chip-row"><v-chip v-for="channel in toArray(item.allowedChannels)" :key="channel" size="small" variant="tonal">{{ channel }}</v-chip></div>
+            </template>
+            <template #item.status="{ item }"><v-chip size="small" :color="item.status === 'ENABLED' ? 'success' : 'default'" variant="tonal">{{ item.status }}</v-chip></template>
+            <template #item.actions="{ item }">
+              <div class="row-actions">
+                <v-btn size="small" variant="tonal" @click="openApplication(item)">编辑</v-btn>
+                <v-btn size="small" color="warning" variant="tonal" @click="rotateSecret(item)">轮换密钥</v-btn>
+              </div>
+            </template>
+          </v-data-table>
+        </v-window-item>
+
+        <v-window-item value="templates">
+          <div class="section-heading">
+            <div><span>TEMPLATES</span><strong>消息模板</strong></div>
+            <v-btn color="primary" prepend-icon="mdi-plus" @click="openTemplate()">新增模板</v-btn>
+          </div>
+          <v-data-table
+            :headers="templateHeaders"
+            :items="templates"
+            :loading="loading"
+            item-value="templateCode"
+            hide-default-footer
+            :items-per-page="-1"
+          >
+            <template #item.template="{ item }">
+              <div class="primary-cell"><strong>{{ item.templateName }}</strong><small>{{ item.templateCode }} · v{{ item.version }}</small></div>
+            </template>
+            <template #item.defaultChannels="{ item }">
+              <div class="chip-row"><v-chip v-for="channel in toArray(item.defaultChannels)" :key="channel" size="small" variant="tonal">{{ channel }}</v-chip></div>
+            </template>
+            <template #item.status="{ item }"><v-chip size="small" :color="item.status === 'ENABLED' ? 'success' : 'default'" variant="tonal">{{ item.status }}</v-chip></template>
+            <template #item.actions="{ item }"><v-btn size="small" variant="tonal" @click="openTemplate(item)">编辑</v-btn></template>
+          </v-data-table>
+        </v-window-item>
+      </v-window>
+    </v-card>
+
+    <v-dialog v-model="applicationDialog.visible" max-width="760" persistent>
+      <v-card>
+        <v-card-title>{{ applicationDialog.editing ? '编辑接入应用' : '新增接入应用' }}</v-card-title>
+        <v-card-text>
+          <v-row dense>
+            <v-col cols="12" md="6"><v-text-field v-model.trim="applicationDialog.form.appCode" label="应用编码" variant="outlined" :disabled="applicationDialog.editing" /></v-col>
+            <v-col cols="12" md="6"><v-text-field v-model.trim="applicationDialog.form.appName" label="应用名称" variant="outlined" /></v-col>
+            <v-col cols="12" md="6"><v-text-field v-model.trim="applicationDialog.form.tenantId" label="租户" variant="outlined" /></v-col>
+            <v-col cols="12" md="6"><v-select v-model="applicationDialog.form.status" label="状态" :items="statusOptions" variant="outlined" /></v-col>
+            <v-col cols="12" md="6"><v-select v-model="applicationDialog.form.allowedChannels" label="允许渠道" :items="channelOptions" multiple chips variant="outlined" /></v-col>
+            <v-col cols="12" md="6"><v-text-field v-model.number="applicationDialog.form.rateLimitPerMinute" label="每分钟限流" type="number" min="1" variant="outlined" /></v-col>
+            <v-col cols="12"><v-text-field v-model="applicationDialog.form.allowedIpsText" label="IP 白名单" hint="多个 IP 使用逗号分隔，* 表示不限制" persistent-hint variant="outlined" /></v-col>
+            <v-col cols="12"><v-text-field v-model.trim="applicationDialog.form.callbackUrl" label="结果回调地址" variant="outlined" clearable /></v-col>
+          </v-row>
+        </v-card-text>
+        <v-card-actions><v-spacer /><v-btn variant="text" @click="applicationDialog.visible = false">取消</v-btn><v-btn color="primary" :loading="applicationDialog.loading" @click="saveApplication">保存</v-btn></v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="templateDialog.visible" max-width="860" persistent>
+      <v-card>
+        <v-card-title>{{ templateDialog.editing ? '编辑消息模板' : '新增消息模板' }}</v-card-title>
+        <v-card-text>
+          <v-row dense>
+            <v-col cols="12" md="6"><v-text-field v-model.trim="templateDialog.form.templateCode" label="模板编码" variant="outlined" :disabled="templateDialog.editing" /></v-col>
+            <v-col cols="12" md="6"><v-text-field v-model.trim="templateDialog.form.templateName" label="模板名称" variant="outlined" /></v-col>
+            <v-col cols="12" md="4"><v-text-field v-model.trim="templateDialog.form.messageType" label="消息类型" variant="outlined" /></v-col>
+            <v-col cols="12" md="4"><v-text-field v-model.number="templateDialog.form.version" label="版本" type="number" min="1" variant="outlined" /></v-col>
+            <v-col cols="12" md="4"><v-select v-model="templateDialog.form.status" label="状态" :items="statusOptions" variant="outlined" /></v-col>
+            <v-col cols="12"><v-select v-model="templateDialog.form.defaultChannels" label="默认渠道" :items="channelOptions" multiple chips variant="outlined" /></v-col>
+            <v-col cols="12" md="6"><v-text-field v-model="templateDialog.form.localTitleTemplate" label="站内信标题模板" variant="outlined" /></v-col>
+            <v-col cols="12" md="6"><v-text-field v-model="templateDialog.form.emailSubjectTemplate" label="邮件主题模板" variant="outlined" /></v-col>
+            <v-col cols="12" md="6"><v-textarea v-model="templateDialog.form.localBodyTemplate" label="站内信正文模板" rows="5" auto-grow variant="outlined" /></v-col>
+            <v-col cols="12" md="6"><v-textarea v-model="templateDialog.form.emailBodyTemplate" label="邮件正文模板" rows="5" auto-grow variant="outlined" /></v-col>
+          </v-row>
+        </v-card-text>
+        <v-card-actions><v-spacer /><v-btn variant="text" @click="templateDialog.visible = false">取消</v-btn><v-btn color="primary" :loading="templateDialog.loading" @click="saveTemplate">保存</v-btn></v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="secretDialog.visible" max-width="560">
+      <v-card>
+        <v-card-title>应用密钥已更新</v-card-title>
+        <v-card-text>
+          <v-alert type="warning" variant="tonal" class="mb-4">密钥只在本次操作中返回，请立即复制并安全保存。</v-alert>
+          <v-text-field :model-value="secretDialog.secret" label="AppSecret" readonly variant="outlined" append-inner-icon="mdi-content-copy" @click:append-inner="copySecret" />
+        </v-card-text>
+        <v-card-actions><v-spacer /><v-btn color="primary" @click="secretDialog.visible = false">已保存</v-btn></v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="2400">{{ snackbar.text }}</v-snackbar>
+  </main>
+</template>
+
+<script setup>
+import { onMounted, reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  listImApplications,
+  listImTemplates,
+  rotateImApplicationSecret,
+  saveImApplication,
+  saveImTemplate,
+} from '@/api/imManagement'
+
+const router = useRouter()
+const activeTab = ref('applications')
+const loading = ref(false)
+const applications = ref([])
+const templates = ref([])
+const channelOptions = ['LOCAL', 'EMAIL']
+const statusOptions = ['ENABLED', 'DISABLED']
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const secretDialog = reactive({ visible: false, secret: '' })
+
+const applicationHeaders = [
+  { title: '应用', key: 'application', minWidth: 220 },
+  { title: '租户', key: 'tenantId', width: 130 },
+  { title: '渠道', key: 'channels', width: 180 },
+  { title: '限流/分钟', key: 'rateLimitPerMinute', width: 120 },
+  { title: '状态', key: 'status', width: 110 },
+  { title: '操作', key: 'actions', sortable: false, width: 210 },
+]
+const templateHeaders = [
+  { title: '模板', key: 'template', minWidth: 230 },
+  { title: '消息类型', key: 'messageType', width: 140 },
+  { title: '默认渠道', key: 'defaultChannels', width: 180 },
+  { title: '状态', key: 'status', width: 110 },
+  { title: '更新时间', key: 'updatedTime', width: 180 },
+  { title: '操作', key: 'actions', sortable: false, width: 100 },
+]
+
+const applicationDialog = reactive({ visible: false, loading: false, editing: false, form: emptyApplication() })
+const templateDialog = reactive({ visible: false, loading: false, editing: false, form: emptyTemplate() })
+
+onMounted(refreshAll)
+
+function emptyApplication() {
+  return { appCode: '', appName: '', tenantId: 'default', allowedChannels: ['LOCAL'], allowedIpsText: '*', rateLimitPerMinute: 600, callbackUrl: '', status: 'ENABLED' }
+}
+function emptyTemplate() {
+  return { templateCode: '', templateName: '', messageType: 'NOTICE', localTitleTemplate: '', localBodyTemplate: '', emailSubjectTemplate: '', emailBodyTemplate: '', defaultChannels: ['LOCAL'], version: 1, status: 'ENABLED' }
+}
+
+async function refreshAll() {
+  loading.value = true
+  try {
+    const [appsResponse, templatesResponse] = await Promise.all([listImApplications(), listImTemplates()])
+    applications.value = Array.isArray(appsResponse?.data) ? appsResponse.data : []
+    templates.value = Array.isArray(templatesResponse?.data) ? templatesResponse.data : []
+  } catch (error) {
+    showMessage(error?.response?.data?.message || 'IM 管理数据加载失败', 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+function openApplication(item = null) {
+  applicationDialog.editing = Boolean(item)
+  applicationDialog.form = item ? {
+    appCode: item.appCode,
+    appName: item.appName,
+    tenantId: item.tenantId || 'default',
+    allowedChannels: toArray(item.allowedChannels),
+    allowedIpsText: toArray(item.allowedIps).join(',') || '*',
+    rateLimitPerMinute: item.rateLimitPerMinute || 600,
+    callbackUrl: item.callbackUrl || '',
+    status: item.status || 'ENABLED',
+  } : emptyApplication()
+  applicationDialog.visible = true
+}
+
+async function saveApplication() {
+  const form = applicationDialog.form
+  if (!form.appCode || !form.appName || !form.allowedChannels.length) {
+    showMessage('应用编码、名称和允许渠道不能为空', 'warning')
+    return
+  }
+  applicationDialog.loading = true
+  try {
+    const response = await saveImApplication({
+      appCode: form.appCode,
+      appName: form.appName,
+      tenantId: form.tenantId || 'default',
+      allowedChannels: form.allowedChannels,
+      allowedIps: form.allowedIpsText.split(',').map(item => item.trim()).filter(Boolean),
+      rateLimitPerMinute: Number(form.rateLimitPerMinute || 600),
+      callbackUrl: form.callbackUrl || undefined,
+      status: form.status,
+    })
+    applicationDialog.visible = false
+    const result = response?.data
+    if (result?.secretChanged && result?.secret) {
+      secretDialog.secret = result.secret
+      secretDialog.visible = true
+    }
+    showMessage('IM 应用配置已保存')
+    await refreshAll()
+  } catch (error) {
+    showMessage(error?.response?.data?.message || 'IM 应用保存失败', 'error')
+  } finally {
+    applicationDialog.loading = false
+  }
+}
+
+async function rotateSecret(item) {
+  if (!window.confirm(`确认轮换应用 ${item.appCode} 的密钥？旧密钥将立即失效。`)) return
+  try {
+    const response = await rotateImApplicationSecret(item.appCode)
+    secretDialog.secret = response?.data?.secret || ''
+    secretDialog.visible = true
+    showMessage('应用密钥已轮换')
+  } catch (error) {
+    showMessage(error?.response?.data?.message || '密钥轮换失败', 'error')
+  }
+}
+
+function openTemplate(item = null) {
+  templateDialog.editing = Boolean(item)
+  templateDialog.form = item ? {
+    templateCode: item.templateCode,
+    templateName: item.templateName,
+    messageType: item.messageType,
+    localTitleTemplate: item.localTitleTemplate || '',
+    localBodyTemplate: item.localBodyTemplate || '',
+    emailSubjectTemplate: item.emailSubjectTemplate || '',
+    emailBodyTemplate: item.emailBodyTemplate || '',
+    defaultChannels: toArray(item.defaultChannels),
+    version: Number(item.version || 1),
+    status: item.status || 'ENABLED',
+  } : emptyTemplate()
+  templateDialog.visible = true
+}
+
+async function saveTemplate() {
+  const form = templateDialog.form
+  if (!form.templateCode || !form.templateName || !form.messageType || !form.defaultChannels.length || Number(form.version) < 1) {
+    showMessage('请完整填写模板必填项', 'warning')
+    return
+  }
+  templateDialog.loading = true
+  try {
+    await saveImTemplate({ ...form, version: Number(form.version) })
+    templateDialog.visible = false
+    showMessage('消息模板已保存')
+    await refreshAll()
+  } catch (error) {
+    showMessage(error?.response?.data?.message || '消息模板保存失败', 'error')
+  } finally {
+    templateDialog.loading = false
+  }
+}
+
+function toArray(value) {
+  if (Array.isArray(value)) return value
+  if (value instanceof Set) return Array.from(value)
+  if (!value) return []
+  return String(value).split(',').map(item => item.trim()).filter(Boolean)
+}
+
+async function copySecret() {
+  try {
+    await navigator.clipboard.writeText(secretDialog.secret)
+    showMessage('密钥已复制')
+  } catch (error) {
+    showMessage('无法自动复制，请手动选择密钥', 'warning')
+  }
+}
+
+function showMessage(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+</script>
+
+<style scoped>
+.im-page { min-height: 100vh; padding: 30px; color: #253431; background: #f4f6f7; }
+.hero { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 22px; padding: 30px 34px; border-radius: 24px; color: #fff; background: linear-gradient(135deg, #4c356e, #7659a7); }
+.hero span { font-size: 11px; font-weight: 800; letter-spacing: .16em; opacity: .72; }
+.hero h1 { margin: 8px 0 0; font-size: 36px; }
+.hero p { margin: 12px 0 0; opacity: .78; }
+.hero-actions { display: flex; gap: 10px; }
+.workspace { border: 1px solid #e0e4e6; border-radius: 18px; background: #fff; }
+.section-heading { display: flex; align-items: center; justify-content: space-between; padding: 22px 24px 12px; }
+.section-heading span, .section-heading strong { display: block; }
+.section-heading span { color: #86749a; font-size: 11px; font-weight: 800; letter-spacing: .12em; }
+.section-heading strong { margin-top: 5px; font-size: 20px; }
+.primary-cell { display: grid; gap: 4px; }
+.primary-cell small { color: #82908d; font-size: 11px; }
+.chip-row, .row-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+@media (max-width: 760px) {
+  .im-page { padding: 16px; }
+  .hero { align-items: flex-start; flex-direction: column; padding: 24px; }
+  .hero h1 { font-size: 28px; }
+  .hero-actions { width: 100%; flex-wrap: wrap; }
+}
+</style>

--- a/src/views/login/PlatformPortalView.vue
+++ b/src/views/login/PlatformPortalView.vue
@@ -1,0 +1,312 @@
+<template>
+  <main class="matrix-shell">
+    <aside class="side-nav">
+      <div class="brand">
+        <div class="brand-mark">M</div>
+        <div class="brand-copy"><strong>Matrix</strong><span>企业智能平台</span></div>
+      </div>
+
+      <nav class="nav-group" aria-label="Matrix 主导航">
+        <button
+          v-for="item in navItems"
+          :key="item.key"
+          type="button"
+          class="nav-item"
+          :class="{ active: activeNav === item.key }"
+          @click="handleNav(item)"
+        >
+          <component :is="item.icon" class="nav-icon" />
+          <span>{{ item.label }}</span>
+        </button>
+      </nav>
+
+      <div class="side-spacer" />
+      <div class="platform-status"><span class="status-dot" /><div><strong>平台运行正常</strong><small>核心服务可用</small></div></div>
+      <button type="button" class="logout-link" @click="handleLogout"><SwitchButton class="nav-icon" /><span>退出登录</span></button>
+    </aside>
+
+    <section class="workspace">
+      <header class="topbar">
+        <div class="page-title"><span>{{ currentDate }}</span><strong>{{ currentPage.title }}</strong><small>{{ currentPage.subtitle }}</small></div>
+        <div class="top-actions">
+          <button type="button" class="top-action" title="新建费用报销" @click="navigateTo('/expenses')"><Plus /></button>
+          <button type="button" class="top-action notification-button" title="消息中心" @click="navigateTo('/notifications')"><Bell /><span class="notice-badge" /></button>
+          <button type="button" class="profile-button" @click="navigateTo('/personal')"><span class="avatar">M</span><span class="profile-copy"><strong>当前用户</strong><small>Matrix 平台</small></span></button>
+        </div>
+      </header>
+
+      <div class="page-content">
+        <WorkbenchPanel
+          v-if="activeNav === 'workbench'"
+          :hero-metrics="heroMetrics"
+          :todos="todos"
+          :recent-items="recentItems"
+          :notices="notices"
+          :quick-actions="quickActions"
+          @navigate="navigateTo"
+          @open-app-center="switchInternalView('apps')"
+          @refresh="refreshWorkbench"
+        />
+        <ApplicationCenterPanel v-else-if="activeNav === 'apps'" :apps="apps" @open="openApp" />
+        <section v-else class="settings-view">
+          <div class="settings-hero"><Setting class="settings-icon" /><span>PLATFORM SETTINGS</span><h1>平台设置</h1><p>配置应用、权限和个性化工作台的后台能力仍在建设中。</p></div>
+          <div class="settings-grid">
+            <article><Grid /><strong>应用配置</strong><span>维护应用入口、状态、分类与展示顺序。</span></article>
+            <article><OfficeBuilding /><strong>组织与权限</strong><span>按租户、组织和角色控制应用可见范围。</span></article>
+            <article><Operation /><strong>工作台配置</strong><span>配置指标、待办、快捷操作和通知内容。</span></article>
+          </div>
+        </section>
+      </div>
+    </section>
+
+    <transition name="toast"><div v-if="snackbar.show" class="toast" :class="snackbar.type">{{ snackbar.text }}</div></transition>
+  </main>
+</template>
+
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { getApps, getWorkbench } from '@/api/platform'
+import ApplicationCenterPanel from '@/components/platform/ApplicationCenterPanel.vue'
+import WorkbenchPanel from '@/components/platform/WorkbenchPanel.vue'
+import { clearToken } from '@/utils/auth'
+import { resolveMatrixIcon } from '@/utils/matrixIcons'
+import {
+  Bell,
+  Calendar,
+  ChatDotRound,
+  Connection,
+  Cpu,
+  DataAnalysis,
+  Files,
+  Grid,
+  House,
+  Link,
+  Message,
+  Notebook,
+  OfficeBuilding,
+  Operation,
+  Plus,
+  Promotion,
+  Setting,
+  SwitchButton,
+  Tickets,
+  TrendCharts,
+  Upload,
+  User,
+  Wallet,
+} from '@element-plus/icons-vue'
+
+const route = useRoute()
+const router = useRouter()
+const snackbar = ref({ show: false, text: '', type: 'info' })
+let toastTimer = null
+const activeNav = ref(resolveInternalView(route.query.view))
+
+const navItems = [
+  { key: 'workbench', label: '工作台', icon: House, internal: true },
+  { key: 'apps', label: '应用中心', icon: Grid, internal: true },
+  { key: 'finance', label: '财务系统', icon: Wallet, path: '/finance', newPage: true },
+  { key: 'workflow', label: '审批中心', icon: Operation, path: '/workflow/tasks' },
+  { key: 'knowledge', label: '知识系统', icon: Notebook, path: '/ai/knowledge' },
+  { key: 'messages', label: '消息中心', icon: Message, path: '/notifications' },
+  { key: 'settings', label: '平台设置', icon: Setting, internal: true },
+]
+
+const pageMap = {
+  workbench: { title: '个人工作台', subtitle: '聚焦今日任务、关键指标与最近工作' },
+  apps: { title: '应用中心', subtitle: '统一进入 Matrix 业务系统与平台能力' },
+  settings: { title: '平台设置', subtitle: '配置应用、权限与个性化工作台' },
+}
+const currentPage = computed(() => pageMap[activeNav.value] || pageMap.workbench)
+const currentDate = computed(() => new Intl.DateTimeFormat('zh-CN', { month: 'long', day: 'numeric', weekday: 'long' }).format(new Date()))
+
+const defaultHeroMetrics = [
+  { label: '月结进度', value: '82%', hint: '较昨日 +11%' },
+  { label: '待我处理', value: '6', hint: '进入审批中心处理' },
+  { label: '本月凭证', value: '1,280', hint: '自动生成 64%' },
+]
+const defaultTodos = [
+  { title: '处理流程待办', desc: '查看费用报销和其他审批任务', path: '/workflow/tasks', priority: 'high' },
+  { title: '确认月结检查项', desc: '总账模块还有 3 项需确认', path: '/ledger/month-end-close-workbench', priority: 'medium' },
+  { title: '复核应付账龄预警', desc: '2 家供应商超过信用期', path: '/payable/aging-credit', priority: 'low' },
+]
+const defaultRecentItems = [
+  { title: '费用报销', detail: '创建或查询报销单', time: '常用', path: '/expenses', icon: Tickets },
+  { title: '资产负债表', detail: '本期财务报表', time: '10:24', path: '/ledger/balance-sheet', icon: DataAnalysis },
+  { title: '往来对账单', detail: '客户与供应商余额核对', time: '周五', path: '/ledger/counterparty-statement', icon: Files },
+]
+const defaultNotices = [
+  { tag: '流程', type: 'platform', title: '统一审批中心已接入', desc: '支持我的待办、已办、我发起和审批处理。' },
+  { tag: '费用', type: 'finance', title: '费用报销已接入工作流', desc: '支持草稿、提交、取消和审批详情。' },
+  { tag: 'IM', type: 'knowledge', title: '消息中心与推送管理已拆分', desc: '个人收件箱和平台管理职责更加清晰。' },
+]
+const defaultQuickActions = [
+  { label: '新增报销', icon: Plus, path: '/expenses' },
+  { label: '审批待办', icon: Operation, path: '/workflow/tasks' },
+  { label: '新增凭证', icon: Tickets, path: '/ledger/voucher' },
+  { label: '查看报表', icon: TrendCharts, path: '/ledger/balance-sheet' },
+  { label: '消息中心', icon: Message, path: '/notifications' },
+  { label: '调度中心', icon: Calendar, path: '/scheduler/jobs' },
+]
+
+const defaultApps = [
+  { key: 'finance', name: '财务系统', desc: '覆盖总账、凭证、应收应付、报表、期末处理和财务基础资料。', meta: '核心业务系统', status: '已上线', category: 'business', tags: ['总账', '应收应付', '报表', '月结'], icon: Wallet, accent: '#15745f', path: '/finance', newPage: true, featured: true, available: true, order: 10 },
+  { key: 'workflow', name: '审批与流程中心', desc: '统一处理待办、查看已办，并追踪我发起的业务流程。', meta: '流程协同平台', status: '已上线', category: 'business', tags: ['审批流', '待办', '流程追踪'], icon: Operation, accent: '#a36a28', path: '/workflow/tasks', featured: true, available: true, order: 20 },
+  { key: 'expense', name: '费用报销', desc: '创建费用报销单、提交审批、取消单据并查看审批详情。', meta: '员工费用应用', status: '已上线', category: 'business', tags: ['费用', '报销', '审批'], icon: Tickets, accent: '#b07a25', path: '/expenses', available: true, order: 30 },
+  { key: 'shared-operations', name: '共享运营', desc: '承载共享任务池、协同处理、进度跟踪与运营质量管理。', meta: '共享服务运营', status: '试运行', category: 'business', tags: ['任务池', '协同', '运营'], icon: Link, accent: '#8a6933', path: '/shared/operations', available: true, order: 40 },
+  { key: 'message-center', name: '消息中心', desc: '查看个人站内消息、实时通知、未读状态和断线同步结果。', meta: '个人消息收件箱', status: '已上线', category: 'platform', tags: ['站内信', 'WebSocket', '已读'], icon: Message, accent: '#7656a8', path: '/notifications', featured: true, available: true, order: 50 },
+  { key: 'im-management', name: 'IM 推送平台', desc: '管理接入应用、AppSecret、渠道权限和消息模板。', meta: '统一消息能力', status: '已上线', category: 'platform', tags: ['应用管理', '密钥', '模板', '渠道'], icon: Message, accent: '#5e438f', path: '/im/management', available: true, order: 60 },
+  { key: 'knowledge', name: '知识系统', desc: '维护制度、流程、业务文档和知识切片，为检索与 AI 问答提供底座。', meta: '企业知识底座', status: '已上线', category: 'intelligence', tags: ['知识库', '文档', '检索', 'RAG'], icon: Notebook, accent: '#2f66a3', path: '/ai/knowledge', available: true, order: 70 },
+  { key: 'scheduler', name: '任务调度中心', desc: '管理定时任务、执行实例、重试、补偿和运行监控。', meta: '平台调度能力', status: '已上线', category: 'platform', tags: ['Quartz', '任务管理', '重试'], icon: Calendar, accent: '#267b83', path: '/scheduler/jobs', available: true, order: 80 },
+  { key: 'openapi', name: 'Matrix 开放平台', desc: '管理外部应用、接口授权、调用日志、异步任务和回调可靠性。', meta: '外部系统接入', status: '已上线', category: 'integration', tags: ['AppKey', 'HMAC', '授权', '回调'], icon: Connection, accent: '#3c6f9f', path: '/openapi', available: true, order: 90 },
+  { key: 'botp', name: 'BOTP 单据转换平台', desc: '配置单据转换规则、字段映射、下推反写、执行追踪和异常对账。', meta: '业务单据集成', status: '已上线', category: 'integration', tags: ['单据转换', '映射规则', '反写'], icon: Promotion, accent: '#8b5d3b', path: '/botp', available: true, order: 100 },
+  { key: 'ai-assistant', name: 'AI 助手', desc: '围绕财务、数据、知识和平台文档提供智能问答与业务辅助。', meta: '智能协作入口', status: '已上线', category: 'intelligence', tags: ['智能问答', '流式输出'], icon: ChatDotRound, accent: '#365bc0', path: '/ai/assistant', available: true, order: 110 },
+  { key: 'master-data', name: '企业建模与主数据', desc: '维护组织、人员、客户、供应商、物料、币种和公共基础资料。', meta: '平台基础服务', status: '已上线', category: 'platform', tags: ['组织', '人员', '客户', '供应商'], icon: OfficeBuilding, accent: '#596d72', path: '/enterprise-modeling', available: true, order: 120 },
+  { key: 'scheduler-operations', name: '调度运行与可靠性中心', desc: '集中查看调度执行、失败记录、补偿任务和异常恢复操作。', meta: '运行保障', status: '已上线', category: 'platform', tags: ['运行中心', '补偿', '异常恢复'], icon: Cpu, accent: '#4c758a', path: '/scheduler/operations', available: true, order: 130 },
+]
+
+const heroMetrics = ref(defaultHeroMetrics)
+const todos = ref(defaultTodos)
+const recentItems = ref(defaultRecentItems)
+const notices = ref(defaultNotices)
+const quickActions = ref(defaultQuickActions)
+const apps = ref(defaultApps)
+
+watch(() => route.query.view, value => { activeNav.value = resolveInternalView(value) })
+onMounted(loadPortalData)
+
+async function loadPortalData() {
+  const [workbenchResult, appsResult] = await Promise.allSettled([getWorkbench(), getApps()])
+  if (workbenchResult.status === 'fulfilled') {
+    const data = unwrapResponse(workbenchResult.value)
+    heroMetrics.value = hydrateList(data.heroMetrics, hydrateMetric, defaultHeroMetrics)
+    todos.value = hydrateList(data.todos, hydrateTodo, defaultTodos)
+    recentItems.value = hydrateList(data.recentItems, hydrateRecent, defaultRecentItems)
+    notices.value = hydrateList(data.notices, hydrateNotice, defaultNotices)
+    quickActions.value = hydrateList(data.quickActions, hydrateQuickAction, defaultQuickActions)
+  }
+  if (appsResult.status === 'fulfilled') {
+    const remoteApps = unwrapResponse(appsResult.value)
+    apps.value = mergeAppCatalog(Array.isArray(remoteApps) ? remoteApps : [])
+  }
+}
+
+function unwrapResponse(response) {
+  if (response?.code && response.code !== 200) throw new Error(response.message || 'platform api error')
+  return response?.data || response || {}
+}
+function hydrateList(source, mapper, fallback) { return Array.isArray(source) && source.length ? source.map(mapper) : fallback }
+function hydrateMetric(item) { return { label: item.label || item.name || item.title, value: item.value, hint: item.hint } }
+function hydrateTodo(item) { return { title: item.title || item.name || item.label, desc: item.desc || item.description || item.detail, path: item.path || item.routePath, priority: item.priority } }
+function hydrateRecent(item) { return { title: item.title || item.name || item.label, detail: item.detail || item.desc || item.description, time: item.time || item.value, path: item.path || item.routePath, icon: resolveMatrixIcon(item.iconKey, Files) } }
+function hydrateNotice(item) { return { tag: item.tag, type: item.type, title: item.title || item.name || item.label, desc: item.desc || item.description || item.detail } }
+function hydrateQuickAction(item) { return { label: item.label || item.name || item.title, icon: resolveMatrixIcon(item.iconKey, Grid), path: item.path || item.routePath } }
+
+function normalizeRemoteKey(item) {
+  const key = item.key || ''
+  const name = item.name || item.title || ''
+  if (key === 'im' || name === 'IM 推送平台') return 'im-management'
+  if (key === 'workflow' || name.includes('工作流')) return 'workflow'
+  return key
+}
+function mergeAppCatalog(remoteApps) {
+  const catalog = defaultApps.map(item => ({ ...item }))
+  const byKey = new Map(catalog.map(item => [item.key, item]))
+  remoteApps.forEach(raw => {
+    const key = normalizeRemoteKey(raw)
+    const target = byKey.get(key)
+    const remote = {
+      key,
+      name: raw.name || raw.title || raw.label,
+      desc: raw.desc || raw.description || raw.detail,
+      meta: raw.meta || raw.hint,
+      status: normalizeStatus(raw.status, raw.available),
+      icon: resolveMatrixIcon(raw.iconKey, Grid),
+      accent: raw.accent,
+      path: raw.path || raw.routePath,
+      newPage: raw.newPage === true,
+      featured: raw.featured === true,
+      available: raw.available !== false,
+    }
+    if (target) {
+      Object.assign(target, {
+        ...remote,
+        name: target.name,
+        desc: target.desc,
+        meta: target.meta,
+        category: target.category,
+        tags: target.tags,
+        icon: raw.iconKey ? remote.icon : target.icon,
+        accent: remote.accent || target.accent,
+        path: target.path,
+        featured: target.featured || remote.featured,
+        order: target.order,
+      })
+    } else {
+      catalog.push({ ...remote, key: key || `remote-${catalog.length + 1}`, category: inferCategory(remote), tags: [], order: 1000 + catalog.length })
+    }
+  })
+  return catalog.sort((left, right) => (left.order || 9999) - (right.order || 9999))
+}
+function inferCategory(app) {
+  const text = `${app.name || ''} ${app.meta || ''}`.toLowerCase()
+  if (text.includes('ai') || text.includes('知识') || text.includes('智能')) return 'intelligence'
+  if (text.includes('开放') || text.includes('集成') || text.includes('botp')) return 'integration'
+  if (text.includes('财务') || text.includes('审批') || text.includes('业务')) return 'business'
+  return 'platform'
+}
+function normalizeStatus(status, available) {
+  if (status === 'ENABLED') return '已上线'
+  if (status === 'DISABLED') return '规划中'
+  return status || (available === false ? '规划中' : '已上线')
+}
+function resolveInternalView(value) { return ['workbench', 'apps', 'settings'].includes(value) ? value : 'workbench' }
+function handleNav(item) { item.internal ? switchInternalView(item.key) : navigateTo(item.path, { newPage: item.newPage }) }
+function switchInternalView(view) { activeNav.value = view; router.replace({ path: '/portal', query: view === 'workbench' ? {} : { view } }) }
+function openApp(app) { app.available === false ? showToast(`${app.name}仍在规划中`) : navigateTo(app.path, { newPage: app.newPage }) }
+function navigateTo(path, options = {}) {
+  if (!path) return showToast('该入口正在接入')
+  if (options.newPage) return window.open(router.resolve(path).href, '_blank', 'noopener')
+  router.push(path)
+}
+async function refreshWorkbench() { showToast('正在刷新工作台', 'success'); await loadPortalData() }
+function handleLogout() { clearToken(); showToast('已退出登录', 'success'); window.setTimeout(() => router.push('/login'), 600) }
+function showToast(text, type = 'info') {
+  snackbar.value = { show: true, text, type }
+  if (toastTimer) window.clearTimeout(toastTimer)
+  toastTimer = window.setTimeout(() => { snackbar.value.show = false }, 2200)
+}
+</script>
+
+<style scoped>
+.matrix-shell { min-height: 100vh; display: flex; color: #1b2d2a; background: #f2f6f5; }
+.side-nav { position: sticky; top: 0; display: flex; width: 226px; height: 100vh; flex: 0 0 226px; flex-direction: column; padding: 24px 16px 18px; border-right: 1px solid #dfe8e5; background: #fff; }
+.brand { display: flex; align-items: center; gap: 12px; padding: 0 8px 26px; }
+.brand-mark { display: grid; width: 42px; height: 42px; place-items: center; border-radius: 14px; color: #fff; background: linear-gradient(135deg, #1e6957, #3d9a7e); font-size: 21px; font-weight: 900; }
+.brand-copy strong, .brand-copy span { display: block; }
+.brand-copy strong { color: #17312d; font-size: 19px; }
+.brand-copy span { margin-top: 3px; color: #7a8986; font-size: 11px; }
+.nav-group { display: grid; gap: 7px; }
+.nav-item, .logout-link { display: flex; align-items: center; gap: 12px; width: 100%; min-height: 44px; padding: 0 13px; border: 0; border-radius: 12px; color: #60716d; background: transparent; cursor: pointer; font: inherit; font-weight: 650; text-align: left; }
+.nav-item:hover, .logout-link:hover { color: #1f6956; background: #f0f8f5; }
+.nav-item.active { color: #1e6956; background: #e8f5f0; box-shadow: inset 3px 0 0 #2f8b70; }
+.nav-icon, .nav-item :deep(svg), .logout-link :deep(svg) { width: 19px; height: 19px; }
+.side-spacer { flex: 1; }
+.platform-status { display: grid; grid-template-columns: 10px minmax(0, 1fr); gap: 10px; align-items: center; margin: 18px 4px; padding: 14px; border: 1px solid #e3ece9; border-radius: 14px; background: #f8fbfa; }
+.status-dot { width: 9px; height: 9px; border-radius: 999px; background: #39a77f; box-shadow: 0 0 0 5px rgba(57,167,127,.11); }
+.platform-status strong, .platform-status small { display: block; }
+.platform-status strong { font-size: 12px; }.platform-status small { margin-top: 3px; color: #879591; font-size: 10px; }
+.logout-link { color: #8a5b5b; }.workspace { min-width: 0; flex: 1; }
+.topbar { position: sticky; z-index: 20; top: 0; display: flex; align-items: center; justify-content: space-between; min-height: 82px; gap: 24px; padding: 14px 30px; border-bottom: 1px solid rgba(218,230,226,.9); background: rgba(247,250,249,.9); backdrop-filter: blur(16px); }
+.page-title span, .page-title strong, .page-title small { display: block; }.page-title span { color: #7e8d89; font-size: 11px; }.page-title strong { margin-top: 3px; font-size: 20px; }.page-title small { margin-top: 2px; color: #87938f; font-size: 11px; }
+.top-actions { display: flex; align-items: center; gap: 9px; }.top-action { position: relative; display: grid; width: 38px; height: 38px; place-items: center; border: 1px solid #dbe7e3; border-radius: 12px; color: #56716a; background: #fff; cursor: pointer; }.top-action svg { width: 18px; height: 18px; }
+.notice-badge { position: absolute; top: 7px; right: 7px; width: 7px; height: 7px; border: 2px solid #fff; border-radius: 999px; background: #e45c58; }
+.profile-button { display: flex; align-items: center; gap: 9px; min-height: 42px; padding: 3px 10px 3px 4px; border: 0; border-radius: 14px; color: inherit; background: transparent; cursor: pointer; }.avatar { display: grid; width: 36px; height: 36px; place-items: center; border-radius: 12px; color: #fff; background: #2f7f6b; font-weight: 800; }.profile-copy strong, .profile-copy small { display: block; text-align: left; }.profile-copy strong { font-size: 12px; }.profile-copy small { color: #87938f; font-size: 10px; }
+.page-content { max-width: 1600px; margin: 0 auto; padding: 28px 30px 42px; }
+.settings-view { display: grid; gap: 24px; }.settings-hero { display: grid; justify-items: start; padding: 42px; border-radius: 28px; color: #fff; background: linear-gradient(135deg, #273b45, #365a61); }.settings-icon { width: 34px; height: 34px; margin-bottom: 18px; }.settings-hero span { color: #b9d5d2; font-size: 11px; font-weight: 800; letter-spacing: .16em; }.settings-hero h1 { margin: 9px 0 0; font-size: 38px; }.settings-hero p { max-width: 640px; margin: 14px 0 0; color: rgba(255,255,255,.72); }
+.settings-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }.settings-grid article { display: grid; min-height: 180px; align-content: start; gap: 12px; padding: 24px; border: 1px solid #e0e9e6; border-radius: 20px; background: #fff; }.settings-grid svg { width: 28px; height: 28px; color: #2f7f6b; }.settings-grid strong { font-size: 17px; }.settings-grid span { color: #73847f; font-size: 13px; line-height: 1.7; }
+.toast { position: fixed; z-index: 100; right: 28px; bottom: 28px; max-width: 360px; padding: 13px 18px; border-radius: 12px; color: #fff; background: #344e49; }.toast.success { background: #23785f; }.toast-enter-active, .toast-leave-active { transition: opacity .2s ease, transform .2s ease; }.toast-enter-from, .toast-leave-to { opacity: 0; transform: translateY(10px); }
+@media (max-width: 920px) { .side-nav { width: 78px; flex-basis: 78px; padding-inline: 10px; }.brand-copy, .nav-item span, .logout-link span, .platform-status div { display: none; }.brand { justify-content: center; padding-inline: 0; }.nav-item, .logout-link { justify-content: center; padding: 0; }.platform-status { grid-template-columns: 1fr; justify-items: center; padding: 12px 6px; }.settings-grid { grid-template-columns: 1fr; } }
+@media (max-width: 680px) { .topbar { align-items: flex-start; padding: 14px 18px; }.profile-copy { display: none; }.page-content { padding: 20px 16px 32px; } }
+</style>

--- a/src/views/login/Portal.vue
+++ b/src/views/login/Portal.vue
@@ -5,7 +5,7 @@
         <div class="brand-mark">M</div>
         <div class="brand-copy">
           <strong>Matrix</strong>
-          <span>企业智能工作台</span>
+          <span>企业智能平台</span>
         </div>
       </div>
 
@@ -15,25 +15,26 @@
           :key="item.key"
           type="button"
           class="nav-item"
-          :class="{ active: activeNav === item.key, disabled: item.disabled }"
-          :title="item.label"
+          :class="{ active: activeNav === item.key }"
           @click="handleNav(item)"
         >
-          <component :is="item.icon" class="svg-icon" />
+          <component :is="item.icon" class="nav-icon" />
           <span>{{ item.label }}</span>
         </button>
       </nav>
 
-      <div class="side-status">
-        <div class="status-dot"></div>
+      <div class="side-spacer"></div>
+
+      <div class="platform-status">
+        <span class="status-dot"></span>
         <div>
-          <span>平台运行正常</span>
-          <strong>99.98%</strong>
+          <strong>平台运行正常</strong>
+          <small>核心服务可用</small>
         </div>
       </div>
 
       <button type="button" class="logout-link" @click="handleLogout">
-        <SwitchButton class="svg-icon" />
+        <SwitchButton class="nav-icon" />
         <span>退出登录</span>
       </button>
     </aside>
@@ -42,191 +43,73 @@
       <header class="topbar">
         <div class="page-title">
           <span>{{ currentDate }}</span>
-          <strong>个人工作台</strong>
+          <strong>{{ currentPage.title }}</strong>
+          <small>{{ currentPage.subtitle }}</small>
         </div>
 
-        <label class="search-box" aria-label="搜索业务、知识与单据">
-          <Search class="svg-icon" />
-          <input v-model="searchKeyword" type="search" placeholder="搜索业务、知识与单据" />
-        </label>
-
         <div class="top-actions">
-          <button type="button" class="icon-button" title="新建事项" @click="showToast('统一新建入口正在接入')">
-            <Plus class="svg-icon" />
+          <button type="button" class="top-action" title="统一新建" @click="showToast('统一新建入口正在接入')">
+            <Plus />
           </button>
-          <button type="button" class="icon-button" title="通知中心" @click="showToast('你有 3 条新的平台通知')">
-            <Bell class="svg-icon" />
+          <button type="button" class="top-action notification-button" title="IM 消息中心" @click="navigateTo('/notifications')">
+            <Bell />
             <span class="notice-badge"></span>
           </button>
-          <button type="button" class="avatar-button" title="个人中心" @click="showToast('个人中心正在设计中')">
-            <span>林</span>
-            <div>
+          <button type="button" class="profile-button" @click="showToast('个人中心正在建设中')">
+            <span class="avatar">林</span>
+            <span class="profile-copy">
               <strong>林澈</strong>
               <small>财务共享中心</small>
-            </div>
+            </span>
           </button>
         </div>
       </header>
 
-      <section class="hero-band" aria-label="Matrix 工作台概览">
-        <img src="/assets/matrix-workbench-hero.png" alt="Matrix 企业工作台视觉概览" class="hero-image" />
-        <div class="hero-shade"></div>
-        <div class="hero-content">
-          <div class="eyebrow">
-            <span></span>
-            Matrix 个人工作台
-          </div>
-          <h1>早上好，林澈</h1>
-          <p>今日待处理 6 项，财务月结正在推进，知识系统与更多业务系统将从这里统一进入。</p>
-          <div class="hero-actions">
-            <button type="button" class="primary-action" @click="navigateTo('/finance', { newPage: true })">
-              <Wallet class="svg-icon" />
-              <span>进入财务系统</span>
-            </button>
-            <button type="button" class="secondary-action" @click="navigateTo('/ai/assistant')">
-              <ChatDotRound class="svg-icon" />
-              <span>询问 AI 助手</span>
-            </button>
-          </div>
-        </div>
+      <div class="page-content">
+        <WorkbenchPanel
+          v-if="activeNav === 'workbench'"
+          :hero-metrics="heroMetrics"
+          :todos="todos"
+          :recent-items="recentItems"
+          :notices="notices"
+          :quick-actions="quickActions"
+          @navigate="navigateTo"
+          @open-app-center="switchInternalView('apps')"
+          @refresh="refreshWorkbench"
+        />
 
-        <div class="hero-metrics" aria-label="今日关键指标">
-          <div v-for="metric in heroMetrics" :key="metric.label" class="metric-item">
-            <span>{{ metric.label }}</span>
-            <strong>{{ metric.value }}</strong>
-            <small>{{ metric.hint }}</small>
-          </div>
-        </div>
-      </section>
+        <ApplicationCenterPanel
+          v-else-if="activeNav === 'apps'"
+          :apps="apps"
+          @open="openApp"
+        />
 
-      <section class="content-grid">
-        <section class="main-column">
-          <div class="section-heading">
-            <div>
-              <span>Application Hub</span>
-              <h2>我的应用</h2>
-            </div>
-            <button type="button" class="text-button" @click="showToast('应用中心将支持按角色配置')">
-              <Grid class="svg-icon" />
-              <span>管理应用</span>
-            </button>
+        <section v-else class="settings-view">
+          <div class="settings-hero">
+            <Setting class="settings-icon" />
+            <span>PLATFORM SETTINGS</span>
+            <h1>平台设置</h1>
+            <p>后续将在这里配置应用可见范围、角色入口、首页偏好和平台级参数。</p>
           </div>
-
-          <div class="app-grid">
-            <article
-              v-for="app in apps"
-              :key="app.name"
-              class="app-card"
-              :class="{ featured: app.featured, disabled: !app.available }"
-              @click="openApp(app)"
-            >
-              <div class="app-card-head">
-                <span class="app-icon" :style="{ '--accent': app.accent }">
-                  <component :is="app.icon" class="svg-icon" />
-                </span>
-                <span class="app-status" :class="{ live: app.available }">{{ app.status }}</span>
-              </div>
-              <h3>{{ app.name }}</h3>
-              <p>{{ app.desc }}</p>
-              <div class="app-card-foot">
-                <span>{{ app.meta }}</span>
-                <ArrowRight class="svg-icon" />
-              </div>
+          <div class="settings-grid">
+            <article>
+              <Grid />
+              <strong>应用配置</strong>
+              <span>维护应用名称、入口、状态、分类和展示顺序。</span>
+            </article>
+            <article>
+              <OfficeBuilding />
+              <strong>组织与权限</strong>
+              <span>按租户、组织、角色控制应用与菜单的可见范围。</span>
+            </article>
+            <article>
+              <Operation />
+              <strong>工作台配置</strong>
+              <span>配置指标、待办、快捷操作和通知内容。</span>
             </article>
           </div>
-
-          <div class="lower-grid">
-            <section class="work-section">
-              <div class="section-heading compact">
-                <div>
-                  <span>Recent</span>
-                  <h2>最近访问</h2>
-                </div>
-              </div>
-              <div class="recent-list">
-                <button
-                  v-for="item in recentItems"
-                  :key="item.title"
-                  type="button"
-                  class="recent-item"
-                  @click="navigateTo(item.path)"
-                >
-                  <component :is="item.icon" class="svg-icon recent-icon" />
-                  <div>
-                    <strong>{{ item.title }}</strong>
-                    <span>{{ item.detail }}</span>
-                  </div>
-                  <small>{{ item.time }}</small>
-                </button>
-              </div>
-            </section>
-
-            <section class="work-section">
-              <div class="section-heading compact">
-                <div>
-                  <span>Notice</span>
-                  <h2>通知动态</h2>
-                </div>
-              </div>
-              <div class="notice-list">
-                <div v-for="notice in notices" :key="notice.title" class="notice-item">
-                  <span :class="['notice-type', notice.type]">{{ notice.tag }}</span>
-                  <div>
-                    <strong>{{ notice.title }}</strong>
-                    <p>{{ notice.desc }}</p>
-                  </div>
-                </div>
-              </div>
-            </section>
-          </div>
         </section>
-
-        <aside class="right-column">
-          <section class="today-panel">
-            <div class="section-heading compact">
-              <div>
-                <span>Today</span>
-                <h2>我的待办</h2>
-              </div>
-              <button type="button" class="icon-button small" title="刷新待办" @click="showToast('待办已刷新')">
-                <Refresh class="svg-icon" />
-              </button>
-            </div>
-
-            <div class="todo-list">
-              <button
-                v-for="todo in todos"
-                :key="todo.title"
-                type="button"
-                class="todo-item"
-                @click="navigateTo(todo.path)"
-              >
-                <span class="todo-priority" :class="todo.priority"></span>
-                <div>
-                  <strong>{{ todo.title }}</strong>
-                  <small>{{ todo.desc }}</small>
-                </div>
-                <Clock class="svg-icon" />
-              </button>
-            </div>
-          </section>
-
-          <section class="quick-panel">
-            <div class="section-heading compact">
-              <div>
-                <span>Quick Actions</span>
-                <h2>快捷操作</h2>
-              </div>
-            </div>
-            <div class="quick-grid">
-              <button v-for="action in quickActions" :key="action.label" type="button" @click="navigateTo(action.path)">
-                <component :is="action.icon" class="svg-icon" />
-                <span>{{ action.label }}</span>
-              </button>
-            </div>
-          </section>
-        </aside>
-      </section>
+      </div>
     </section>
 
     <transition name="toast">
@@ -238,29 +121,30 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
-import { getWorkbench } from '@/api/platform'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { getApps, getWorkbench } from '@/api/platform'
+import ApplicationCenterPanel from '@/components/platform/ApplicationCenterPanel.vue'
+import WorkbenchPanel from '@/components/platform/WorkbenchPanel.vue'
 import { clearToken } from '@/utils/auth'
 import { resolveMatrixIcon } from '@/utils/matrixIcons'
 import {
-  ArrowRight,
   Bell,
-  Briefcase,
   Calendar,
   ChatDotRound,
-  Clock,
+  Connection,
+  Cpu,
   DataAnalysis,
-  DocumentChecked,
   Files,
   Grid,
   House,
   Link,
+  Message,
   Notebook,
   OfficeBuilding,
+  Operation,
   Plus,
-  Refresh,
-  Search,
+  Promotion,
   Setting,
   SwitchButton,
   Tickets,
@@ -270,27 +154,43 @@ import {
   Wallet,
 } from '@element-plus/icons-vue'
 
+const route = useRoute()
 const router = useRouter()
-const activeNav = ref('workbench')
-const searchKeyword = ref('')
 const snackbar = ref({ show: false, text: '', type: 'info' })
 let toastTimer = null
 
-const currentDate = computed(() => {
-  return new Intl.DateTimeFormat('zh-CN', {
-    month: 'long',
-    day: 'numeric',
-    weekday: 'long',
-  }).format(new Date())
-})
+const activeNav = ref(resolveInternalView(route.query.view))
 
 const navItems = [
-  { key: 'workbench', label: '工作台', icon: House },
-  { key: 'apps', label: '应用中心', icon: Grid },
+  { key: 'workbench', label: '工作台', icon: House, internal: true },
+  { key: 'apps', label: '应用中心', icon: Grid, internal: true },
   { key: 'finance', label: '财务系统', icon: Wallet, path: '/finance', newPage: true },
   { key: 'knowledge', label: '知识系统', icon: Notebook, path: '/ai/knowledge' },
-  { key: 'settings', label: '平台设置', icon: Setting },
+  { key: 'im', label: 'IM 推送平台', icon: Message, path: '/notifications' },
+  { key: 'settings', label: '平台设置', icon: Setting, internal: true },
 ]
+
+const pageMap = {
+  workbench: {
+    title: '个人工作台',
+    subtitle: '聚焦今日任务、关键指标与最近工作',
+  },
+  apps: {
+    title: '应用中心',
+    subtitle: '统一进入 Matrix 业务系统与平台能力',
+  },
+  settings: {
+    title: '平台设置',
+    subtitle: '配置应用、权限与个性化工作台',
+  },
+}
+
+const currentPage = computed(() => pageMap[activeNav.value] || pageMap.workbench)
+const currentDate = computed(() => new Intl.DateTimeFormat('zh-CN', {
+  month: 'long',
+  day: 'numeric',
+  weekday: 'long',
+}).format(new Date()))
 
 const defaultHeroMetrics = [
   { label: '月结进度', value: '82%', hint: '较昨日 +11%' },
@@ -298,85 +198,22 @@ const defaultHeroMetrics = [
   { label: '本月凭证', value: '1,280', hint: '自动生成 64%' },
 ]
 
-const defaultApps = [
-  {
-    name: '财务系统',
-    desc: '总账、应收应付、报表、月结协同统一入口。',
-    meta: '核心系统',
-    status: '已上线',
-    icon: Wallet,
-    accent: '#0f8a6a',
-    path: '/finance',
-    newPage: true,
-    featured: true,
-    available: true,
-  },
-  {
-    name: '知识系统',
-    desc: '沉淀制度、流程、案例与业务问答，连接 AI 助手。',
-    meta: '知识底座',
-    status: '已上线',
-    icon: Notebook,
-    accent: '#1769aa',
-    path: '/ai/knowledge',
-    available: true,
-  },
-  {
-    name: '审批系统',
-    desc: '费用、付款、合同与组织审批流的统一处理中心。',
-    meta: '流程能力',
-    status: '规划中',
-    icon: DocumentChecked,
-    accent: '#b7791f',
-    available: false,
-  },
-  {
-    name: '项目系统',
-    desc: '项目预算、成本归集、里程碑与经营分析。',
-    meta: '业务协同',
-    status: '规划中',
-    icon: Briefcase,
-    accent: '#6f7b35',
-    available: false,
-  },
-  {
-    name: 'AI 助手',
-    desc: '围绕财务、数据与知识的智能问答入口。',
-    meta: '智能协作',
-    status: '已上线',
-    icon: ChatDotRound,
-    accent: '#2454a6',
-    path: '/ai/assistant',
-    available: true,
-  },
-  {
-    name: '基础服务',
-    desc: '企业建模、主数据、人员与组织基础能力。',
-    meta: '平台底座',
-    status: '已上线',
-    icon: OfficeBuilding,
-    accent: '#56636f',
-    path: '/base-data',
-    available: true,
-  },
-]
-
 const defaultTodos = [
-  { title: '确认 4 月月结检查项', desc: '总账模块还有 3 项需确认', path: '/ledger/month-end-close-workbench', priority: 'high' },
+  { title: '确认月结检查项', desc: '总账模块还有 3 项需确认', path: '/ledger/month-end-close-workbench', priority: 'high' },
   { title: '复核应付账龄预警', desc: '2 家供应商超过信用期', path: '/payable/aging-credit', priority: 'medium' },
   { title: '补充现金流通知单', desc: '经营活动现金流待勾稽', path: '/ledger/cashflow-notice-check', priority: 'low' },
 ]
 
 const defaultRecentItems = [
-  { title: '资产负债表', detail: '2026 年 4 月报表', time: '10:24', path: '/ledger/balance-sheet', icon: DataAnalysis },
+  { title: '资产负债表', detail: '本期财务报表', time: '10:24', path: '/ledger/balance-sheet', icon: DataAnalysis },
   { title: '凭证协同检查', detail: '自动生成凭证复核', time: '昨天', path: '/ledger/voucher-collaboration-check', icon: Tickets },
   { title: '往来对账单', detail: '客户与供应商余额核对', time: '周五', path: '/ledger/counterparty-statement', icon: Files },
 ]
 
 const defaultNotices = [
   { tag: '财务', type: 'finance', title: '月结监控中心已更新', desc: '新增异常凭证定位与结转进度提醒。' },
-  { tag: '平台', type: 'platform', title: 'Matrix 工作台升级', desc: '多系统入口、待办与最近访问已整合。' },
-  { tag: '知识', type: 'knowledge', title: '知识系统进入产品设计', desc: '后续会接入制度、问答与文档资产。' },
+  { tag: '平台', type: 'platform', title: '应用中心完成重构', desc: '工作台与应用目录已拆分为不同职责。' },
+  { tag: 'IM', type: 'knowledge', title: '实时消息能力已接入', desc: '支持消息中心、断线同步和已读回执。' },
 ]
 
 const defaultQuickActions = [
@@ -385,36 +222,201 @@ const defaultQuickActions = [
   { label: '查看报表', icon: TrendCharts, path: '/ledger/balance-sheet' },
   { label: '企业建模', icon: Link, path: '/enterprise-modeling' },
   { label: '我的档案', icon: User, path: '/personal' },
-  { label: '日程日历', icon: Calendar, path: '/ledger/period-monitor-center' },
+  { label: '调度中心', icon: Calendar, path: '/scheduler/jobs' },
+]
+
+const defaultApps = [
+  {
+    key: 'finance',
+    name: '财务系统',
+    desc: '覆盖总账、凭证、应收应付、报表、期末处理和财务基础资料。',
+    meta: '核心业务系统',
+    status: '已上线',
+    category: 'business',
+    tags: ['总账', '应收应付', '报表', '月结'],
+    icon: Wallet,
+    accent: '#15745f',
+    path: '/finance',
+    newPage: true,
+    featured: true,
+    available: true,
+    order: 10,
+  },
+  {
+    key: 'knowledge',
+    name: '知识系统',
+    desc: '统一维护制度、流程、业务文档和知识切片，为检索与 AI 问答提供底座。',
+    meta: '企业知识底座',
+    status: '已上线',
+    category: 'intelligence',
+    tags: ['知识库', '文档', '检索', 'RAG'],
+    icon: Notebook,
+    accent: '#2f66a3',
+    path: '/ai/knowledge',
+    featured: true,
+    available: true,
+    order: 20,
+  },
+  {
+    key: 'im',
+    name: 'IM 推送平台',
+    desc: '提供站内消息、邮件通知、WebSocket 实时推送、同步恢复和已读回执。',
+    meta: '统一消息能力',
+    status: '已上线',
+    category: 'platform',
+    tags: ['WebSocket', '消息中心', '邮件', 'ACK'],
+    icon: Message,
+    accent: '#7356a8',
+    path: '/notifications',
+    featured: true,
+    available: true,
+    order: 30,
+  },
+  {
+    key: 'workflow',
+    name: '工作流与共享运营',
+    desc: '承载审批任务、费用报销流程、共享任务池、协同处理和状态追踪。',
+    meta: '流程协同平台',
+    status: '已上线',
+    category: 'business',
+    tags: ['审批流', '费用报销', '任务池', '协同'],
+    icon: Operation,
+    accent: '#a36a28',
+    path: '/shared/operations',
+    available: true,
+    order: 40,
+  },
+  {
+    key: 'scheduler',
+    name: '任务调度中心',
+    desc: '管理定时任务、执行实例、重试、补偿、运行监控和可靠性处置。',
+    meta: '平台调度能力',
+    status: '已上线',
+    category: 'platform',
+    tags: ['Quartz', '任务管理', '重试', '监控'],
+    icon: Calendar,
+    accent: '#267b83',
+    path: '/scheduler/jobs',
+    available: true,
+    order: 50,
+  },
+  {
+    key: 'openapi',
+    name: 'Matrix 开放平台',
+    desc: '管理外部应用、接口授权、数据范围、调用日志、异步任务和回调可靠性。',
+    meta: '外部系统接入',
+    status: '已上线',
+    category: 'integration',
+    tags: ['AppKey', 'HMAC', '授权', '回调'],
+    icon: Connection,
+    accent: '#3c6f9f',
+    path: '/openapi',
+    available: true,
+    order: 60,
+  },
+  {
+    key: 'botp',
+    name: 'BOTP 单据转换平台',
+    desc: '配置单据转换规则、字段映射、下推反写、执行追踪和异常对账。',
+    meta: '业务单据集成',
+    status: '已上线',
+    category: 'integration',
+    tags: ['单据转换', '映射规则', '反写', '对账'],
+    icon: Promotion,
+    accent: '#8b5d3b',
+    path: '/botp',
+    available: true,
+    order: 70,
+  },
+  {
+    key: 'ai-assistant',
+    name: 'AI 助手',
+    desc: '围绕财务、数据、知识和平台文档提供智能问答与业务辅助。',
+    meta: '智能协作入口',
+    status: '已上线',
+    category: 'intelligence',
+    tags: ['智能问答', '流式输出', '业务助手'],
+    icon: ChatDotRound,
+    accent: '#365bc0',
+    path: '/ai/assistant',
+    available: true,
+    order: 80,
+  },
+  {
+    key: 'master-data',
+    name: '企业建模与主数据',
+    desc: '维护组织、人员、客户、供应商、物料、币种和公共基础资料。',
+    meta: '平台基础服务',
+    status: '已上线',
+    category: 'platform',
+    tags: ['组织', '人员', '客户', '供应商'],
+    icon: OfficeBuilding,
+    accent: '#596d72',
+    path: '/enterprise-modeling',
+    available: true,
+    order: 90,
+  },
+  {
+    key: 'scheduler-operations',
+    name: '调度运行与可靠性中心',
+    desc: '集中查看调度执行、失败记录、补偿任务和异常恢复操作。',
+    meta: '运行保障',
+    status: '已上线',
+    category: 'platform',
+    tags: ['运行中心', '补偿', '异常恢复'],
+    icon: Cpu,
+    accent: '#4c758a',
+    path: '/scheduler/operations',
+    available: true,
+    order: 100,
+  },
 ]
 
 const heroMetrics = ref(defaultHeroMetrics)
-const apps = ref(defaultApps)
 const todos = ref(defaultTodos)
 const recentItems = ref(defaultRecentItems)
 const notices = ref(defaultNotices)
 const quickActions = ref(defaultQuickActions)
+const apps = ref(defaultApps)
 
-onMounted(loadWorkbench)
+watch(() => route.query.view, (view) => {
+  activeNav.value = resolveInternalView(view)
+})
 
-async function loadWorkbench() {
-  try {
-    const res = await getWorkbench()
-    const data = unwrapResponse(res)
-    heroMetrics.value = hydrateList(data.heroMetrics, hydrateMetric, defaultHeroMetrics)
-    apps.value = hydrateList(data.apps, hydrateApp, defaultApps)
-    todos.value = hydrateList(data.todos, hydrateTodo, defaultTodos)
-    recentItems.value = hydrateList(data.recentItems, hydrateRecent, defaultRecentItems)
-    notices.value = hydrateList(data.notices, hydrateNotice, defaultNotices)
-    quickActions.value = hydrateList(data.quickActions, hydrateQuickAction, defaultQuickActions)
-  } catch (error) {
-    console.warn('Matrix workbench config fallback to local data', error)
+onMounted(loadPortalData)
+
+async function loadPortalData() {
+  const [workbenchResult, appsResult] = await Promise.allSettled([
+    getWorkbench(),
+    getApps(),
+  ])
+
+  if (workbenchResult.status === 'fulfilled') {
+    try {
+      const data = unwrapResponse(workbenchResult.value)
+      heroMetrics.value = hydrateList(data.heroMetrics, hydrateMetric, defaultHeroMetrics)
+      todos.value = hydrateList(data.todos, hydrateTodo, defaultTodos)
+      recentItems.value = hydrateList(data.recentItems, hydrateRecent, defaultRecentItems)
+      notices.value = hydrateList(data.notices, hydrateNotice, defaultNotices)
+      quickActions.value = hydrateList(data.quickActions, hydrateQuickAction, defaultQuickActions)
+    } catch (error) {
+      console.warn('Matrix workbench config fallback to local data', error)
+    }
+  }
+
+  if (appsResult.status === 'fulfilled') {
+    try {
+      const remoteApps = unwrapResponse(appsResult.value)
+      apps.value = mergeAppCatalog(Array.isArray(remoteApps) ? remoteApps : [])
+    } catch (error) {
+      console.warn('Matrix application center fallback to local catalog', error)
+    }
   }
 }
 
 function unwrapResponse(res) {
   if (res?.code && res.code !== 200) {
-    throw new Error(res.message || 'workbench api error')
+    throw new Error(res.message || 'platform api error')
   }
   return res?.data || res || {}
 }
@@ -431,21 +433,6 @@ function hydrateMetric(item) {
     label: item.label || item.name || item.title,
     value: item.value,
     hint: item.hint,
-  }
-}
-
-function hydrateApp(item) {
-  return {
-    name: item.name || item.title || item.label,
-    desc: item.desc || item.description || item.detail,
-    meta: item.meta || item.hint,
-    status: item.status,
-    icon: resolveMatrixIcon(item.iconKey, Grid),
-    accent: item.accent,
-    path: item.path || item.routePath,
-    newPage: item.newPage === true,
-    featured: item.featured === true,
-    available: item.available !== false,
   }
 }
 
@@ -485,21 +472,100 @@ function hydrateQuickAction(item) {
   }
 }
 
-function handleNav(item) {
-  if (item.disabled) {
-    showToast(`${item.label}正在规划中`)
-    return
-  }
-
-  activeNav.value = item.key
-  if (item.path) {
-    navigateTo(item.path, { newPage: item.newPage })
+function hydrateRemoteApp(item) {
+  return {
+    key: item.key,
+    name: item.name || item.title || item.label,
+    desc: item.desc || item.description || item.detail,
+    meta: item.meta || item.hint,
+    status: normalizeStatus(item.status, item.available),
+    icon: resolveMatrixIcon(item.iconKey, Grid),
+    accent: item.accent,
+    path: item.path || item.routePath,
+    newPage: item.newPage === true,
+    featured: item.featured === true,
+    available: item.available !== false,
   }
 }
 
+function mergeAppCatalog(remoteApps) {
+  const catalog = defaultApps.map((item) => ({ ...item }))
+  const byKey = new Map(catalog.map((item) => [item.key, item]))
+  const byName = new Map(catalog.map((item) => [item.name, item]))
+
+  remoteApps.forEach((raw) => {
+    const remote = hydrateRemoteApp(raw)
+    const target = byKey.get(remote.key) || byName.get(remote.name)
+    if (target) {
+      Object.assign(target, {
+        ...remote,
+        category: target.category,
+        tags: target.tags,
+        icon: raw.iconKey ? remote.icon : target.icon,
+        accent: remote.accent || target.accent,
+        path: remote.path || target.path,
+        meta: remote.meta || target.meta,
+        order: target.order,
+      })
+      return
+    }
+
+    catalog.push({
+      ...remote,
+      key: remote.key || `remote-${catalog.length + 1}`,
+      category: inferCategory(remote),
+      tags: [],
+      order: 1000 + catalog.length,
+    })
+  })
+
+  return catalog.sort((left, right) => (left.order || 9999) - (right.order || 9999))
+}
+
+function inferCategory(app) {
+  const text = `${app.name || ''} ${app.meta || ''}`.toLowerCase()
+  if (text.includes('ai') || text.includes('知识') || text.includes('智能')) {
+    return 'intelligence'
+  }
+  if (text.includes('开放') || text.includes('集成') || text.includes('botp')) {
+    return 'integration'
+  }
+  if (text.includes('财务') || text.includes('审批') || text.includes('业务')) {
+    return 'business'
+  }
+  return 'platform'
+}
+
+function normalizeStatus(status, available) {
+  if (status === 'ENABLED') {
+    return '已上线'
+  }
+  if (status === 'DISABLED') {
+    return '规划中'
+  }
+  return status || (available === false ? '规划中' : '已上线')
+}
+
+function resolveInternalView(value) {
+  return ['workbench', 'apps', 'settings'].includes(value) ? value : 'workbench'
+}
+
+function handleNav(item) {
+  if (item.internal) {
+    switchInternalView(item.key)
+    return
+  }
+  navigateTo(item.path, { newPage: item.newPage })
+}
+
+function switchInternalView(view) {
+  activeNav.value = view
+  router.replace({ path: '/portal', query: view === 'workbench' ? {} : { view } })
+}
+
 function openApp(app) {
-  if (!app.available) {
-    showToast(`${app.name}正在规划中，将作为 Matrix 的下一批系统入口`)
+  if (app.available === false) {
+    showToast(`${app.name}仍在规划中`)
     return
   }
   navigateTo(app.path, { newPage: app.newPage })
@@ -511,21 +577,22 @@ function navigateTo(path, options = {}) {
     return
   }
   if (options.newPage) {
-    openRouteInNewPage(path)
+    const url = router.resolve(path).href
+    window.open(url, '_blank', 'noopener')
     return
   }
   router.push(path)
 }
 
-function openRouteInNewPage(path) {
-  const url = router.resolve(path).href
-  window.open(url, '_blank', 'noopener')
+async function refreshWorkbench() {
+  showToast('正在刷新工作台', 'success')
+  await loadPortalData()
 }
 
 function handleLogout() {
   clearToken()
   showToast('已退出登录', 'success')
-  window.setTimeout(() => router.push('/login'), 700)
+  window.setTimeout(() => router.push('/login'), 600)
 }
 
 function showToast(text, type = 'info') {
@@ -543,990 +610,425 @@ function showToast(text, type = 'info') {
 .matrix-shell {
   min-height: 100vh;
   display: flex;
-  background:
-    linear-gradient(180deg, rgba(247, 250, 249, 0.96) 0%, rgba(237, 243, 244, 0.96) 100%),
-    #f4f7f8;
-  color: #17202c;
-}
-
-.svg-icon {
-  width: 18px;
-  height: 18px;
-  flex: 0 0 auto;
+  color: #1b2d2a;
+  background: #f2f6f5;
 }
 
 .side-nav {
-  width: 236px;
-  min-height: 100vh;
   position: sticky;
   top: 0;
-  align-self: flex-start;
   display: flex;
+  width: 226px;
+  height: 100vh;
+  flex: 0 0 226px;
   flex-direction: column;
-  gap: 22px;
-  padding: 22px 16px;
-  border-right: 1px solid rgba(26, 42, 58, 0.1);
-  background: rgba(255, 255, 255, 0.88);
-  backdrop-filter: blur(18px);
+  padding: 24px 16px 18px;
+  border-right: 1px solid #dfe8e5;
+  background: #ffffff;
 }
 
 .brand {
   display: flex;
   align-items: center;
   gap: 12px;
-  min-width: 0;
+  padding: 0 8px 26px;
 }
 
 .brand-mark {
+  display: grid;
   width: 42px;
   height: 42px;
-  border-radius: 8px;
-  display: grid;
   place-items: center;
+  border-radius: 14px;
   color: #ffffff;
-  font-size: 22px;
-  font-weight: 800;
-  background: linear-gradient(135deg, #0d5f69 0%, #0f8a6a 58%, #d6a23a 100%);
-  box-shadow: 0 12px 28px rgba(15, 138, 106, 0.22);
+  background: linear-gradient(135deg, #1e6957, #3d9a7e);
+  box-shadow: 0 10px 22px rgba(30, 105, 87, 0.25);
+  font-size: 21px;
+  font-weight: 900;
 }
 
-.brand-copy {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
+.brand-copy strong,
+.brand-copy span {
+  display: block;
 }
 
 .brand-copy strong {
+  color: #17312d;
   font-size: 19px;
-  line-height: 1.1;
+  letter-spacing: 0.04em;
 }
 
 .brand-copy span {
-  margin-top: 4px;
-  color: #667482;
-  font-size: 12px;
+  margin-top: 3px;
+  color: #7a8986;
+  font-size: 11px;
 }
 
 .nav-group {
   display: grid;
-  gap: 6px;
+  gap: 7px;
 }
 
 .nav-item,
-.logout-link,
-.text-button,
-.primary-action,
-.secondary-action,
-.recent-item,
-.todo-item,
-.quick-grid button {
-  border: 0;
-  font: inherit;
-  cursor: pointer;
-}
-
-.nav-item {
-  min-height: 44px;
+.logout-link {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 0 12px;
-  border-radius: 8px;
-  color: #4c5967;
+  width: 100%;
+  min-height: 44px;
+  padding: 0 13px;
+  border: 0;
+  border-radius: 12px;
+  color: #60716d;
   background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 650;
   text-align: left;
-  transition: background 0.18s ease, color 0.18s ease, transform 0.18s ease;
+  transition: color 0.18s ease, background 0.18s ease, transform 0.18s ease;
 }
 
-.nav-item:hover {
-  color: #0d5f69;
-  background: rgba(13, 95, 105, 0.08);
+.nav-item:hover,
+.logout-link:hover {
+  color: #1f6956;
+  background: #f0f8f5;
+  transform: translateX(2px);
 }
 
 .nav-item.active {
-  color: #0c5b63;
-  background: rgba(15, 138, 106, 0.12);
-  font-weight: 700;
+  color: #1e6956;
+  background: #e8f5f0;
+  box-shadow: inset 3px 0 0 #2f8b70;
 }
 
-.nav-item.disabled {
-  color: #9aa4ad;
+.nav-icon,
+.nav-item :deep(svg),
+.logout-link :deep(svg) {
+  width: 19px;
+  height: 19px;
 }
 
-.side-status {
-  margin-top: auto;
-  display: flex;
-  align-items: center;
+.side-spacer {
+  flex: 1;
+}
+
+.platform-status {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr);
   gap: 10px;
-  padding: 12px;
-  border-radius: 8px;
-  border: 1px solid rgba(15, 138, 106, 0.16);
-  background: #f4fbf7;
+  align-items: center;
+  margin: 18px 4px;
+  padding: 14px;
+  border: 1px solid #e3ece9;
+  border-radius: 14px;
+  background: #f8fbfa;
 }
 
 .status-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: #12a66a;
-  box-shadow: 0 0 0 5px rgba(18, 166, 106, 0.12);
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #39a77f;
+  box-shadow: 0 0 0 5px rgba(57, 167, 127, 0.11);
 }
 
-.side-status span,
-.side-status strong {
+.platform-status strong,
+.platform-status small {
   display: block;
 }
 
-.side-status span {
-  color: #5c6976;
+.platform-status strong {
+  color: #36534d;
   font-size: 12px;
 }
 
-.side-status strong {
-  margin-top: 2px;
-  color: #152331;
-  font-size: 15px;
+.platform-status small {
+  margin-top: 3px;
+  color: #879591;
+  font-size: 10px;
 }
 
 .logout-link {
-  min-height: 40px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 0 12px;
-  border-radius: 8px;
-  color: #6a7480;
-  background: #f7f9fa;
-}
-
-.logout-link:hover {
-  color: #a64024;
-  background: #fff2ec;
+  color: #8a5b5b;
 }
 
 .workspace {
-  flex: 1;
   min-width: 0;
-  padding: 20px 24px 34px;
+  flex: 1;
 }
 
 .topbar {
-  min-height: 58px;
-  display: grid;
-  grid-template-columns: minmax(180px, 260px) minmax(260px, 1fr) auto;
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  display: flex;
   align-items: center;
-  gap: 18px;
+  justify-content: space-between;
+  min-height: 82px;
+  gap: 24px;
+  padding: 14px 30px;
+  border-bottom: 1px solid rgba(218, 230, 226, 0.9);
+  background: rgba(247, 250, 249, 0.9);
+  backdrop-filter: blur(16px);
 }
 
-.page-title {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
+.page-title span,
+.page-title strong,
+.page-title small {
+  display: block;
 }
 
 .page-title span {
-  color: #74808c;
-  font-size: 13px;
+  color: #7e8d89;
+  font-size: 11px;
 }
 
 .page-title strong {
+  margin-top: 3px;
+  color: #172d29;
+  font-size: 20px;
+}
+
+.page-title small {
   margin-top: 2px;
-  font-size: 22px;
-}
-
-.search-box {
-  height: 44px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 0 14px;
-  border: 1px solid rgba(28, 44, 61, 0.1);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 10px 30px rgba(34, 53, 73, 0.06);
-}
-
-.search-box .svg-icon {
-  color: #7f8d99;
-}
-
-.search-box input {
-  width: 100%;
-  min-width: 0;
-  border: 0;
-  outline: 0;
-  color: #17202c;
-  background: transparent;
-  font-size: 14px;
-}
-
-.search-box input::placeholder {
-  color: #8b96a1;
+  color: #87938f;
+  font-size: 11px;
 }
 
 .top-actions {
   display: flex;
   align-items: center;
-  gap: 10px;
-  min-width: 0;
+  gap: 9px;
 }
 
-.icon-button {
-  width: 42px;
-  height: 42px;
+.top-action {
   position: relative;
   display: grid;
+  width: 38px;
+  height: 38px;
   place-items: center;
-  border-radius: 8px;
-  border: 1px solid rgba(28, 44, 61, 0.1);
-  color: #354151;
+  border: 1px solid #dbe7e3;
+  border-radius: 12px;
+  color: #56716a;
   background: #ffffff;
   cursor: pointer;
 }
 
-.icon-button:hover {
-  color: #0f766e;
-  border-color: rgba(15, 118, 110, 0.24);
-}
-
-.icon-button.small {
-  width: 34px;
-  height: 34px;
+.top-action svg {
+  width: 18px;
+  height: 18px;
 }
 
 .notice-badge {
-  width: 8px;
-  height: 8px;
   position: absolute;
-  top: 9px;
-  right: 9px;
-  border-radius: 50%;
-  background: #d67c21;
+  top: 7px;
+  right: 7px;
+  width: 7px;
+  height: 7px;
+  border: 2px solid #ffffff;
+  border-radius: 999px;
+  background: #e45c58;
 }
 
-.avatar-button {
-  min-width: 168px;
-  height: 44px;
+.profile-button {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 0 10px 0 8px;
-  border: 1px solid rgba(28, 44, 61, 0.1);
-  border-radius: 8px;
-  background: #ffffff;
-  color: #17202c;
+  gap: 9px;
+  min-height: 42px;
+  padding: 3px 10px 3px 4px;
+  border: 0;
+  border-radius: 14px;
+  color: inherit;
+  background: transparent;
   cursor: pointer;
+}
+
+.avatar {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 12px;
+  color: #ffffff;
+  background: #2f7f6b;
+  font-weight: 800;
+}
+
+.profile-copy strong,
+.profile-copy small {
+  display: block;
   text-align: left;
 }
 
-.avatar-button > span {
-  width: 30px;
-  height: 30px;
-  display: grid;
-  place-items: center;
-  border-radius: 8px;
-  background: #0d5f69;
-  color: #ffffff;
-  font-weight: 700;
-}
-
-.avatar-button div {
-  min-width: 0;
-}
-
-.avatar-button strong,
-.avatar-button small {
-  display: block;
-  white-space: nowrap;
-}
-
-.avatar-button strong {
-  font-size: 13px;
-}
-
-.avatar-button small {
-  margin-top: 1px;
-  color: #73808d;
-  font-size: 11px;
-}
-
-.hero-band {
-  min-height: 316px;
-  position: relative;
-  overflow: hidden;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 440px);
-  align-items: end;
-  gap: 18px;
-  margin-top: 12px;
-  padding: 34px;
-  border-radius: 8px;
-  border: 1px solid rgba(18, 32, 45, 0.12);
-  background: #10222b;
-  box-shadow: 0 22px 58px rgba(26, 42, 58, 0.16);
-}
-
-.hero-image,
-.hero-shade {
-  position: absolute;
-  inset: 0;
-}
-
-.hero-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.hero-shade {
-  background:
-    linear-gradient(90deg, rgba(10, 28, 34, 0.82) 0%, rgba(10, 28, 34, 0.58) 38%, rgba(10, 28, 34, 0.18) 74%),
-    linear-gradient(180deg, rgba(10, 28, 34, 0.08) 0%, rgba(10, 28, 34, 0.48) 100%);
-}
-
-.hero-content,
-.hero-metrics {
-  position: relative;
-  z-index: 1;
-}
-
-.eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: #b7ead8;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.eyebrow span {
-  width: 24px;
-  height: 2px;
-  border-radius: 2px;
-  background: #d6a23a;
-}
-
-.hero-content h1 {
-  max-width: 680px;
-  margin: 14px 0 12px;
-  color: #ffffff;
-  font-size: 42px;
-  line-height: 1.12;
-  letter-spacing: 0;
-}
-
-.hero-content p {
-  max-width: 640px;
-  margin: 0;
-  color: rgba(255, 255, 255, 0.82);
-  font-size: 16px;
-  line-height: 1.8;
-}
-
-.hero-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 24px;
-}
-
-.primary-action,
-.secondary-action {
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 9px;
-  padding: 0 18px;
-  border-radius: 8px;
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
-}
-
-.primary-action {
-  color: #ffffff;
-  background: #0f8a6a;
-  box-shadow: 0 14px 30px rgba(15, 138, 106, 0.3);
-}
-
-.secondary-action {
-  color: #f8fbfb;
-  border: 1px solid rgba(255, 255, 255, 0.34);
-  background: rgba(255, 255, 255, 0.12);
-}
-
-.primary-action:hover,
-.secondary-action:hover {
-  transform: translateY(-1px);
-}
-
-.hero-metrics {
-  display: grid;
-  gap: 10px;
-  align-self: stretch;
-}
-
-.metric-item {
-  display: grid;
-  align-content: center;
-  gap: 4px;
-  min-height: 82px;
-  padding: 14px 16px;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(8, 27, 33, 0.45);
-  backdrop-filter: blur(16px);
-}
-
-.metric-item span {
-  color: rgba(255, 255, 255, 0.68);
+.profile-copy strong {
+  color: #2a3e3a;
   font-size: 12px;
 }
 
-.metric-item strong {
-  color: #ffffff;
-  font-size: 25px;
-  line-height: 1;
+.profile-copy small {
+  margin-top: 2px;
+  color: #87938f;
+  font-size: 10px;
 }
 
-.metric-item small {
-  color: #b7ead8;
-  font-size: 12px;
+.page-content {
+  max-width: 1600px;
+  margin: 0 auto;
+  padding: 28px 30px 42px;
 }
 
-.content-grid {
+.settings-view {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 352px;
-  gap: 22px;
-  margin-top: 24px;
+  gap: 24px;
 }
 
-.main-column,
-.right-column {
-  min-width: 0;
+.settings-hero {
+  display: grid;
+  justify-items: start;
+  padding: 42px;
+  border-radius: 28px;
+  color: #ffffff;
+  background: linear-gradient(135deg, #273b45 0%, #365a61 100%);
 }
 
-.section-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-  margin-bottom: 14px;
+.settings-icon {
+  width: 34px;
+  height: 34px;
+  margin-bottom: 18px;
 }
 
-.section-heading.compact {
-  margin-bottom: 12px;
-}
-
-.section-heading span {
-  display: block;
-  color: #0f766e;
+.settings-hero span {
+  color: #b9d5d2;
   font-size: 11px;
   font-weight: 800;
-  letter-spacing: 0;
-  text-transform: uppercase;
+  letter-spacing: 0.16em;
 }
 
-.section-heading h2 {
-  margin: 2px 0 0;
-  font-size: 22px;
-  line-height: 1.25;
+.settings-hero h1 {
+  margin: 9px 0 0;
+  font-size: 38px;
 }
 
-.section-heading.compact h2 {
-  font-size: 18px;
+.settings-hero p {
+  max-width: 640px;
+  margin: 14px 0 0;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.75;
 }
 
-.text-button {
-  min-height: 36px;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 12px;
-  border-radius: 8px;
-  color: #1b4d5c;
-  background: #e8f4f1;
-}
-
-.app-grid {
+.settings-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 14px;
-}
-
-.app-card {
-  min-height: 186px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 18px;
-  border: 1px solid rgba(26, 42, 58, 0.1);
-  border-radius: 8px;
-  background: #ffffff;
-  box-shadow: 0 14px 38px rgba(34, 53, 73, 0.08);
-  cursor: pointer;
-  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
-}
-
-.app-card:hover {
-  transform: translateY(-2px);
-  border-color: rgba(15, 138, 106, 0.34);
-  box-shadow: 0 18px 46px rgba(34, 53, 73, 0.12);
-}
-
-.app-card.featured {
-  color: #ffffff;
-  border-color: rgba(15, 138, 106, 0.24);
-  background:
-    linear-gradient(135deg, rgba(13, 95, 105, 0.96) 0%, rgba(15, 138, 106, 0.94) 58%, rgba(35, 65, 76, 0.98) 100%);
-}
-
-.app-card.disabled {
-  cursor: default;
-  background: #f7f9fa;
-}
-
-.app-card-head,
-.app-card-foot {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.app-icon {
-  width: 42px;
-  height: 42px;
-  display: grid;
-  place-items: center;
-  border-radius: 8px;
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 12%, #ffffff);
-}
-
-.app-card.featured .app-icon {
-  color: #ffffff;
-  background: rgba(255, 255, 255, 0.16);
-}
-
-.app-status {
-  display: inline-flex;
-  align-items: center;
-  min-height: 24px;
-  padding: 0 9px;
-  border-radius: 999px;
-  color: #7b8792;
-  background: #edf1f3;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.app-status.live {
-  color: #0f6f55;
-  background: #def6eb;
-}
-
-.app-card.featured .app-status {
-  color: #173126;
-  background: #b7ead8;
-}
-
-.app-card h3 {
-  margin: 4px 0 0;
-  font-size: 19px;
-  line-height: 1.28;
-}
-
-.app-card p {
-  margin: 0;
-  color: #65717d;
-  font-size: 14px;
-  line-height: 1.65;
-}
-
-.app-card.featured p {
-  color: rgba(255, 255, 255, 0.78);
-}
-
-.app-card-foot {
-  margin-top: auto;
-  color: #53606d;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.app-card.featured .app-card-foot {
-  color: #ffffff;
-}
-
-.lower-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
-  margin-top: 22px;
 }
 
-.work-section,
-.today-panel,
-.quick-panel {
-  padding: 18px;
-  border: 1px solid rgba(26, 42, 58, 0.1);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 14px 38px rgba(34, 53, 73, 0.07);
-}
-
-.right-column {
+.settings-grid article {
   display: grid;
+  min-height: 180px;
   align-content: start;
-  gap: 16px;
-}
-
-.recent-list,
-.notice-list,
-.todo-list {
-  display: grid;
-  gap: 10px;
-}
-
-.recent-item,
-.todo-item {
-  width: 100%;
-  min-height: 62px;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: center;
   gap: 12px;
-  padding: 12px;
-  border-radius: 8px;
-  color: #17202c;
-  background: #f7f9fa;
-  text-align: left;
+  padding: 24px;
+  border: 1px solid #e0e9e6;
+  border-radius: 20px;
+  background: #ffffff;
+  box-shadow: 0 12px 30px rgba(38, 70, 68, 0.06);
 }
 
-.recent-item:hover,
-.todo-item:hover {
-  background: #edf6f3;
+.settings-grid svg {
+  width: 28px;
+  height: 28px;
+  color: #2f7f6b;
 }
 
-.recent-icon {
-  color: #0d5f69;
+.settings-grid strong {
+  color: #203632;
+  font-size: 17px;
 }
 
-.recent-item strong,
-.recent-item span,
-.todo-item strong,
-.todo-item small {
-  display: block;
-}
-
-.recent-item strong,
-.todo-item strong {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 14px;
-}
-
-.recent-item span,
-.todo-item small {
-  margin-top: 3px;
-  color: #697684;
-  font-size: 12px;
-}
-
-.recent-item small {
-  color: #87929d;
-  font-size: 12px;
-}
-
-.notice-item {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 10px;
-  padding: 12px 0;
-  border-bottom: 1px solid rgba(26, 42, 58, 0.08);
-}
-
-.notice-item:last-child {
-  border-bottom: 0;
-}
-
-.notice-type {
-  min-width: 42px;
-  height: 24px;
-  display: inline-grid;
-  place-items: center;
-  border-radius: 999px;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.notice-type.finance {
-  color: #0f6f55;
-  background: #def6eb;
-}
-
-.notice-type.platform {
-  color: #2454a6;
-  background: #e4edff;
-}
-
-.notice-type.knowledge {
-  color: #8a5a0f;
-  background: #fff1cf;
-}
-
-.notice-item strong {
-  display: block;
-  font-size: 14px;
-}
-
-.notice-item p {
-  margin: 4px 0 0;
-  color: #667482;
-  font-size: 12px;
-  line-height: 1.6;
-}
-
-.todo-priority {
-  width: 9px;
-  height: 38px;
-  border-radius: 999px;
-  background: #8ca0ad;
-}
-
-.todo-priority.high {
-  background: #c9562d;
-}
-
-.todo-priority.medium {
-  background: #d6a23a;
-}
-
-.todo-priority.low {
-  background: #0f8a6a;
-}
-
-.todo-item .svg-icon {
-  color: #96a0aa;
-}
-
-.quick-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.quick-grid button {
-  min-height: 76px;
-  display: grid;
-  place-items: center;
-  gap: 8px;
-  padding: 12px 8px;
-  border-radius: 8px;
-  color: #263443;
-  background: #f7f9fa;
-}
-
-.quick-grid button:hover {
-  color: #0d5f69;
-  background: #edf6f3;
-}
-
-.quick-grid span {
-  max-width: 100%;
-  overflow-wrap: anywhere;
+.settings-grid span {
+  color: #73847f;
   font-size: 13px;
-  font-weight: 700;
+  line-height: 1.7;
 }
 
 .toast {
   position: fixed;
-  right: 24px;
-  bottom: 24px;
-  z-index: 30;
-  max-width: min(360px, calc(100vw - 48px));
-  padding: 12px 16px;
-  border-radius: 8px;
+  z-index: 100;
+  right: 28px;
+  bottom: 28px;
+  max-width: 360px;
+  padding: 13px 18px;
+  border-radius: 12px;
   color: #ffffff;
-  background: #17202c;
-  box-shadow: 0 16px 38px rgba(23, 32, 44, 0.22);
+  background: #344e49;
+  box-shadow: 0 16px 38px rgba(20, 48, 43, 0.24);
+  font-size: 13px;
 }
 
 .toast.success {
-  background: #0f8a6a;
+  background: #23785f;
 }
 
 .toast-enter-active,
 .toast-leave-active {
-  transition: opacity 0.18s ease, transform 0.18s ease;
+  transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 .toast-enter-from,
 .toast-leave-to {
   opacity: 0;
-  transform: translateY(8px);
+  transform: translateY(10px);
 }
 
-@media (max-width: 1180px) {
-  .content-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .right-column {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  }
-}
-
-@media (max-width: 980px) {
+@media (max-width: 920px) {
   .side-nav {
-    width: 84px;
-    padding: 18px 12px;
-    align-items: center;
+    width: 78px;
+    flex-basis: 78px;
+    padding-inline: 10px;
   }
 
   .brand-copy,
   .nav-item span,
-  .side-status,
-  .logout-link span {
+  .logout-link span,
+  .platform-status div {
     display: none;
+  }
+
+  .brand {
+    justify-content: center;
+    padding-inline: 0;
   }
 
   .nav-item,
   .logout-link {
-    width: 46px;
     justify-content: center;
     padding: 0;
   }
 
-  .topbar {
+  .platform-status {
     grid-template-columns: 1fr;
+    justify-items: center;
+    padding: 12px 6px;
   }
 
-  .top-actions {
-    justify-content: space-between;
-  }
-
-  .search-box {
-    order: 3;
-  }
-
-  .hero-band {
+  .settings-grid {
     grid-template-columns: 1fr;
-  }
-
-  .hero-metrics {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .app-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 720px) {
-  .matrix-shell {
-    display: block;
+@media (max-width: 680px) {
+  .topbar {
+    align-items: flex-start;
+    padding: 14px 18px;
   }
 
-  .side-nav {
-    width: 100%;
-    min-height: auto;
-    position: sticky;
-    top: 0;
-    z-index: 10;
-    flex-direction: row;
-    align-items: center;
-    gap: 12px;
-    overflow-x: auto;
-    padding: 10px 12px;
-    border-right: 0;
-    border-bottom: 1px solid rgba(26, 42, 58, 0.1);
-  }
-
-  .brand-copy,
-  .nav-item span,
-  .logout-link span {
+  .profile-copy,
+  .top-action:first-child {
     display: none;
   }
 
-  .nav-group {
-    display: flex;
-    gap: 6px;
-  }
-
-  .workspace {
-    padding: 16px 14px 28px;
-  }
-
-  .top-actions {
-    flex-wrap: wrap;
-  }
-
-  .avatar-button {
-    min-width: 144px;
-  }
-
-  .hero-band {
-    min-height: auto;
-    padding: 26px 18px;
-  }
-
-  .hero-content h1 {
-    font-size: 32px;
-  }
-
-  .hero-content p {
-    font-size: 14px;
-  }
-
-  .hero-metrics,
-  .app-grid,
-  .lower-grid,
-  .right-column {
-    grid-template-columns: 1fr;
-  }
-
-  .metric-item {
-    min-height: 72px;
-  }
-
-  .section-heading {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .text-button {
-    align-self: stretch;
-    justify-content: center;
-  }
-
-  .toast {
-    right: 14px;
-    bottom: 14px;
-    max-width: calc(100vw - 28px);
-  }
-}
-
-@media (max-width: 430px) {
-  .top-actions {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    width: 100%;
-  }
-
-  .icon-button {
-    width: 100%;
-  }
-
-  .avatar-button {
-    grid-column: 1 / -1;
-    width: 100%;
-  }
-
-  .primary-action,
-  .secondary-action {
-    width: 100%;
+  .page-content {
+    padding: 20px 16px 32px;
   }
 }
 </style>

--- a/src/views/login/expense/ExpenseReimbursementView.vue
+++ b/src/views/login/expense/ExpenseReimbursementView.vue
@@ -1,0 +1,490 @@
+<template>
+  <main class="expense-page">
+    <section class="hero">
+      <div>
+        <span>EXPENSE REIMBURSEMENT</span>
+        <h1>费用报销</h1>
+        <p>创建报销单、提交审批，并追踪财务单据与工作流状态。</p>
+      </div>
+      <div class="hero-actions">
+        <v-btn variant="tonal" prepend-icon="mdi-format-list-checks" @click="router.push('/workflow/tasks')">流程任务</v-btn>
+        <v-btn color="primary" prepend-icon="mdi-plus" @click="resetCreateForm">新建报销</v-btn>
+      </div>
+    </section>
+
+    <section class="workspace-grid">
+      <v-card class="create-card" elevation="0">
+        <v-card-title>新建报销单</v-card-title>
+        <v-card-subtitle>当前后端暂未提供报销单列表，请通过单据 ID 或流程中心追踪已发起记录。</v-card-subtitle>
+        <v-card-text>
+          <v-form ref="createFormRef">
+            <v-row dense>
+              <v-col cols="12" md="6">
+                <v-text-field v-model.trim="createForm.tenantId" label="租户" variant="outlined" :rules="requiredRules" />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-text-field v-model.trim="createForm.applicantId" label="申请人编号" variant="outlined" :rules="requiredRules" />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-text-field v-model.trim="createForm.departmentCode" label="部门编码" variant="outlined" :rules="requiredRules" />
+              </v-col>
+              <v-col cols="12" md="3">
+                <v-text-field v-model.number="createForm.amount" label="金额" type="number" min="0.01" step="0.01" variant="outlined" :rules="amountRules" />
+              </v-col>
+              <v-col cols="12" md="3">
+                <v-select v-model="createForm.currency" label="币种" :items="currencyOptions" variant="outlined" />
+              </v-col>
+              <v-col cols="12">
+                <v-textarea v-model.trim="createForm.description" label="报销事由" variant="outlined" rows="4" auto-grow :rules="requiredRules" />
+              </v-col>
+            </v-row>
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="resetCreateForm">重置</v-btn>
+          <v-btn color="primary" :loading="creating" @click="createDocument">保存草稿</v-btn>
+        </v-card-actions>
+      </v-card>
+
+      <div class="detail-column">
+        <v-card class="lookup-card" elevation="0">
+          <v-card-text>
+            <div class="lookup-row">
+              <v-text-field
+                v-model.trim="lookupId"
+                label="报销单 ID"
+                prepend-inner-icon="mdi-magnify"
+                variant="outlined"
+                density="comfortable"
+                hide-details
+                @keydown.enter="loadDocument"
+              />
+              <v-btn color="primary" :loading="loading" @click="loadDocument">查询</v-btn>
+            </div>
+          </v-card-text>
+        </v-card>
+
+        <v-card v-if="document" class="detail-card" elevation="0">
+          <div class="detail-heading">
+            <div>
+              <span>{{ document.documentNumber || document.id }}</span>
+              <h2>{{ document.description }}</h2>
+            </div>
+            <v-chip :color="statusColor(document.status)" variant="tonal">{{ statusText(document.status) }}</v-chip>
+          </div>
+
+          <v-card-text>
+            <div class="metric-grid">
+              <article><span>金额</span><strong>{{ formatMoney(document.amount, document.currency) }}</strong></article>
+              <article><span>申请人</span><strong>{{ document.applicantId }}</strong></article>
+              <article><span>部门</span><strong>{{ document.departmentCode }}</strong></article>
+              <article><span>版本</span><strong>v{{ document.version }}</strong></article>
+            </div>
+
+            <v-list lines="two" density="comfortable" class="detail-list">
+              <v-list-item title="报销单 ID" :subtitle="document.id" />
+              <v-list-item title="工作流实例" :subtitle="document.workflowInstanceId || '尚未提交审批'" />
+              <v-list-item title="创建时间" :subtitle="formatTime(document.createdAt)" />
+              <v-list-item title="提交时间" :subtitle="formatTime(document.submittedAt)" />
+              <v-list-item title="完成时间" :subtitle="formatTime(document.completedAt)" />
+            </v-list>
+          </v-card-text>
+
+          <v-card-actions class="detail-actions">
+            <v-btn v-if="isDraft" variant="tonal" prepend-icon="mdi-pencil" @click="openEdit">编辑</v-btn>
+            <v-btn v-if="isDraft" color="primary" prepend-icon="mdi-send" @click="openSubmit">提交审批</v-btn>
+            <v-btn v-if="canCancel" color="error" variant="tonal" prepend-icon="mdi-cancel" @click="openCancel">取消单据</v-btn>
+            <v-btn variant="text" prepend-icon="mdi-timeline-text" :loading="approvalLoading" @click="loadApprovalDetail">审批详情</v-btn>
+          </v-card-actions>
+        </v-card>
+
+        <v-card v-else class="empty-card" elevation="0">
+          <v-icon size="48">mdi-receipt-text-outline</v-icon>
+          <strong>尚未选择报销单</strong>
+          <span>创建新草稿，或输入报销单 ID 查询。</span>
+        </v-card>
+      </div>
+    </section>
+
+    <v-card v-if="approvalDetail" class="approval-card" elevation="0">
+      <div class="approval-heading">
+        <div>
+          <span>APPROVAL DETAIL</span>
+          <h2>审批与关联数据</h2>
+        </div>
+        <v-btn variant="text" icon="mdi-close" @click="approvalDetail = null" />
+      </div>
+      <v-row>
+        <v-col v-for="section in approvalSections" :key="section.key" cols="12" md="6">
+          <article class="json-panel">
+            <strong>{{ section.title }}</strong>
+            <pre>{{ prettyJson(section.value) }}</pre>
+          </article>
+        </v-col>
+      </v-row>
+    </v-card>
+
+    <v-dialog v-model="editDialog.visible" max-width="720" persistent>
+      <v-card>
+        <v-card-title>编辑报销草稿</v-card-title>
+        <v-card-text>
+          <v-row dense>
+            <v-col cols="12" md="6"><v-text-field v-model="editDialog.form.operatorId" label="操作人" variant="outlined" /></v-col>
+            <v-col cols="12" md="6"><v-text-field v-model="editDialog.form.departmentCode" label="部门编码" variant="outlined" /></v-col>
+            <v-col cols="12" md="8"><v-text-field v-model.number="editDialog.form.amount" label="金额" type="number" min="0.01" step="0.01" variant="outlined" /></v-col>
+            <v-col cols="12" md="4"><v-select v-model="editDialog.form.currency" label="币种" :items="currencyOptions" variant="outlined" /></v-col>
+            <v-col cols="12"><v-textarea v-model="editDialog.form.description" label="报销事由" variant="outlined" rows="4" auto-grow /></v-col>
+          </v-row>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="editDialog.visible = false">取消</v-btn>
+          <v-btn color="primary" :loading="editDialog.loading" @click="saveEdit">保存</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="submitDialog.visible" max-width="560" persistent>
+      <v-card>
+        <v-card-title>提交费用报销</v-card-title>
+        <v-card-text>
+          <v-text-field v-model="submitDialog.operatorId" label="操作人" variant="outlined" />
+          <v-text-field v-model="submitDialog.definitionKey" label="流程定义" variant="outlined" hint="默认 expense-reimbursement" persistent-hint />
+          <v-textarea v-model="submitDialog.comment" label="提交说明" variant="outlined" rows="3" class="mt-3" />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="submitDialog.visible = false">取消</v-btn>
+          <v-btn color="primary" :loading="submitDialog.loading" @click="submitDocument">确认提交</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="cancelDialog.visible" max-width="520" persistent>
+      <v-card>
+        <v-card-title>取消费用报销</v-card-title>
+        <v-card-text>
+          <v-text-field v-model="cancelDialog.operatorId" label="操作人" variant="outlined" />
+          <v-textarea v-model="cancelDialog.reason" label="取消原因" variant="outlined" rows="3" />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="cancelDialog.visible = false">返回</v-btn>
+          <v-btn color="error" :loading="cancelDialog.loading" @click="cancelDocument">确认取消</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="2400">{{ snackbar.text }}</v-snackbar>
+  </main>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  cancelExpense,
+  createExpense,
+  getExpense,
+  getExpenseApprovalDetail,
+  submitExpense,
+  updateExpense,
+} from '@/api/expense'
+import { getCurrentUserId } from '@/utils/currentUser'
+
+const route = useRoute()
+const router = useRouter()
+const currentUserId = getCurrentUserId()
+const createFormRef = ref(null)
+const creating = ref(false)
+const loading = ref(false)
+const approvalLoading = ref(false)
+const lookupId = ref('')
+const document = ref(null)
+const approvalDetail = ref(null)
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+
+const createForm = reactive({
+  tenantId: 'default',
+  applicantId: currentUserId,
+  departmentCode: '',
+  amount: null,
+  currency: 'CNY',
+  description: '',
+})
+const editDialog = reactive({ visible: false, loading: false, form: {} })
+const submitDialog = reactive({
+  visible: false,
+  loading: false,
+  operatorId: currentUserId,
+  definitionKey: 'expense-reimbursement',
+  comment: '',
+})
+const cancelDialog = reactive({ visible: false, loading: false, operatorId: currentUserId, reason: '' })
+
+const requiredRules = [value => Boolean(String(value || '').trim()) || '此项不能为空']
+const amountRules = [value => Number(value) > 0 || '金额必须大于 0']
+const currencyOptions = ['CNY', 'USD', 'HKD', 'EUR', 'JPY']
+
+const isDraft = computed(() => (document.value?.status || '').toUpperCase() === 'DRAFT')
+const canCancel = computed(() => !['COMPLETED', 'CANCELLED', 'REJECTED'].includes((document.value?.status || '').toUpperCase()))
+const approvalSections = computed(() => {
+  if (!approvalDetail.value) return []
+  return [
+    { key: 'binding', title: '流程绑定', value: approvalDetail.value.binding },
+    { key: 'workflow', title: '流程实例', value: approvalDetail.value.workflow },
+    { key: 'tasks', title: '审批任务', value: approvalDetail.value.tasks },
+    { key: 'timeline', title: '审批时间线', value: approvalDetail.value.timeline },
+    { key: 'attachments', title: '附件', value: approvalDetail.value.attachments },
+  ]
+})
+
+watch(() => route.query.expenseId, value => {
+  if (typeof value === 'string' && value && value !== document.value?.id) {
+    lookupId.value = value
+    loadDocument()
+  }
+})
+
+onMounted(() => {
+  if (typeof route.query.expenseId === 'string' && route.query.expenseId) {
+    lookupId.value = route.query.expenseId
+    loadDocument()
+  }
+})
+
+async function createDocument() {
+  const validation = await createFormRef.value?.validate()
+  if (validation && !validation.valid) return
+  creating.value = true
+  try {
+    const response = await createExpense({ ...createForm, amount: Number(createForm.amount) })
+    document.value = response?.data || null
+    lookupId.value = document.value?.id || ''
+    approvalDetail.value = null
+    syncQuery()
+    showMessage('报销草稿已创建')
+  } catch (error) {
+    showMessage(error?.response?.data?.message || '报销单创建失败', 'error')
+  } finally {
+    creating.value = false
+  }
+}
+
+async function loadDocument() {
+  if (!lookupId.value) {
+    showMessage('请输入报销单 ID', 'warning')
+    return
+  }
+  loading.value = true
+  try {
+    const response = await getExpense(lookupId.value)
+    document.value = response?.data || null
+    approvalDetail.value = null
+    syncQuery()
+  } catch (error) {
+    document.value = null
+    showMessage(error?.response?.data?.message || '报销单查询失败', 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+function openEdit() {
+  editDialog.form = {
+    operatorId: currentUserId || document.value.applicantId,
+    departmentCode: document.value.departmentCode,
+    amount: Number(document.value.amount),
+    currency: document.value.currency || 'CNY',
+    description: document.value.description,
+    version: document.value.version,
+  }
+  editDialog.visible = true
+}
+
+async function saveEdit() {
+  const form = editDialog.form
+  if (!form.operatorId || !form.departmentCode || !form.description || Number(form.amount) <= 0) {
+    showMessage('请完整填写编辑信息', 'warning')
+    return
+  }
+  editDialog.loading = true
+  try {
+    const response = await updateExpense(document.value.id, { ...form, amount: Number(form.amount) })
+    document.value = response?.data || document.value
+    editDialog.visible = false
+    showMessage('报销草稿已更新')
+  } catch (error) {
+    showMessage(error?.response?.data?.message || '报销单更新失败', 'error')
+  } finally {
+    editDialog.loading = false
+  }
+}
+
+function openSubmit() {
+  submitDialog.operatorId = currentUserId || document.value.applicantId
+  submitDialog.definitionKey = 'expense-reimbursement'
+  submitDialog.comment = ''
+  submitDialog.visible = true
+}
+
+async function submitDocument() {
+  if (!submitDialog.operatorId) {
+    showMessage('操作人不能为空', 'warning')
+    return
+  }
+  submitDialog.loading = true
+  try {
+    const response = await submitExpense(document.value.id, {
+      operatorId: submitDialog.operatorId,
+      definitionKey: submitDialog.definitionKey || undefined,
+      comment: submitDialog.comment || undefined,
+    })
+    document.value = response?.data || document.value
+    submitDialog.visible = false
+    showMessage('报销单已提交审批')
+    await loadApprovalDetail()
+  } catch (error) {
+    showMessage(error?.response?.data?.message || '提交审批失败', 'error')
+  } finally {
+    submitDialog.loading = false
+  }
+}
+
+function openCancel() {
+  cancelDialog.operatorId = currentUserId || document.value.applicantId
+  cancelDialog.reason = ''
+  cancelDialog.visible = true
+}
+
+async function cancelDocument() {
+  if (!cancelDialog.operatorId) {
+    showMessage('操作人不能为空', 'warning')
+    return
+  }
+  cancelDialog.loading = true
+  try {
+    const response = await cancelExpense(document.value.id, {
+      operatorId: cancelDialog.operatorId,
+      reason: cancelDialog.reason || undefined,
+    })
+    document.value = response?.data || document.value
+    cancelDialog.visible = false
+    showMessage('报销单已取消')
+  } catch (error) {
+    showMessage(error?.response?.data?.message || '取消报销单失败', 'error')
+  } finally {
+    cancelDialog.loading = false
+  }
+}
+
+async function loadApprovalDetail() {
+  if (!document.value?.id) return
+  approvalLoading.value = true
+  try {
+    const response = await getExpenseApprovalDetail(document.value.id)
+    approvalDetail.value = response?.data || null
+  } catch (error) {
+    showMessage(error?.response?.data?.message || '审批详情加载失败', 'error')
+  } finally {
+    approvalLoading.value = false
+  }
+}
+
+function resetCreateForm() {
+  Object.assign(createForm, {
+    tenantId: 'default',
+    applicantId: currentUserId,
+    departmentCode: '',
+    amount: null,
+    currency: 'CNY',
+    description: '',
+  })
+  createFormRef.value?.resetValidation()
+}
+
+function syncQuery() {
+  if (!document.value?.id) return
+  router.replace({ path: '/expenses', query: { expenseId: document.value.id } })
+}
+
+function statusText(value) {
+  const map = {
+    DRAFT: '草稿', SUBMITTED: '审批中', APPROVING: '审批中', APPROVED: '已审批',
+    COMPLETED: '已完成', REJECTED: '已驳回', CANCELLED: '已取消', RETURNED: '已退回',
+  }
+  return map[(value || '').toUpperCase()] || value || '-'
+}
+
+function statusColor(value) {
+  const status = (value || '').toUpperCase()
+  if (['APPROVED', 'COMPLETED'].includes(status)) return 'success'
+  if (['REJECTED', 'CANCELLED'].includes(status)) return 'error'
+  if (['SUBMITTED', 'APPROVING'].includes(status)) return 'primary'
+  if (status === 'RETURNED') return 'warning'
+  return 'default'
+}
+
+function formatMoney(amount, currency) {
+  const value = Number(amount || 0)
+  try {
+    return new Intl.NumberFormat('zh-CN', { style: 'currency', currency: currency || 'CNY' }).format(value)
+  } catch (error) {
+    return `${currency || 'CNY'} ${value.toFixed(2)}`
+  }
+}
+
+function formatTime(value) {
+  if (!value) return '-'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('zh-CN', { hour12: false })
+}
+
+function prettyJson(value) {
+  if (value == null) return '暂无数据'
+  try { return JSON.stringify(value, null, 2) } catch (error) { return String(value) }
+}
+
+function showMessage(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+</script>
+
+<style scoped>
+.expense-page { min-height: 100vh; padding: 30px; color: #233632; background: #f5f7f6; }
+.hero { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 22px; padding: 30px 34px; border-radius: 24px; color: #fff; background: linear-gradient(135deg, #6f5320, #b3832e); }
+.hero span { font-size: 11px; font-weight: 800; letter-spacing: .16em; opacity: .72; }
+.hero h1 { margin: 8px 0 0; font-size: 36px; }
+.hero p { margin: 12px 0 0; opacity: .78; }
+.hero-actions { display: flex; gap: 10px; }
+.workspace-grid { display: grid; grid-template-columns: minmax(360px, .9fr) minmax(460px, 1.1fr); gap: 20px; align-items: start; }
+.detail-column { display: grid; gap: 16px; }
+.create-card, .lookup-card, .detail-card, .empty-card, .approval-card { border: 1px solid #e0e7e4; border-radius: 18px; background: #fff; }
+.lookup-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; align-items: center; }
+.detail-heading, .approval-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; padding: 22px 24px 8px; }
+.detail-heading span, .approval-heading span { color: #8a7a5d; font-size: 11px; font-weight: 800; letter-spacing: .12em; }
+.detail-heading h2, .approval-heading h2 { margin: 5px 0 0; font-size: 22px; }
+.metric-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
+.metric-grid article { padding: 14px; border-radius: 13px; background: #f7f4ec; }
+.metric-grid span, .metric-grid strong { display: block; }
+.metric-grid span { color: #8d8069; font-size: 11px; }
+.metric-grid strong { margin-top: 6px; font-size: 15px; }
+.detail-list { margin-top: 14px; border-radius: 12px; background: #fafbfa; }
+.detail-actions { flex-wrap: wrap; padding: 8px 20px 20px; }
+.empty-card { display: grid; min-height: 310px; place-items: center; align-content: center; gap: 10px; color: #87948f; }
+.empty-card strong { color: #425a54; }
+.approval-card { margin-top: 20px; padding: 0 22px 22px; }
+.json-panel { height: 100%; padding: 16px; border: 1px solid #e6ece9; border-radius: 14px; background: #f8faf9; }
+.json-panel pre { max-height: 320px; overflow: auto; margin: 12px 0 0; white-space: pre-wrap; word-break: break-word; font-size: 12px; }
+@media (max-width: 1050px) { .workspace-grid { grid-template-columns: 1fr; } }
+@media (max-width: 720px) {
+  .expense-page { padding: 16px; }
+  .hero { align-items: flex-start; flex-direction: column; padding: 24px; }
+  .hero h1 { font-size: 28px; }
+  .hero-actions { width: 100%; flex-wrap: wrap; }
+  .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+</style>

--- a/src/views/login/workflow/WorkflowTaskCenterView.vue
+++ b/src/views/login/workflow/WorkflowTaskCenterView.vue
@@ -1,0 +1,354 @@
+<template>
+  <main class="workflow-page">
+    <section class="hero">
+      <div>
+        <span>WORKFLOW TASK CENTER</span>
+        <h1>工作流任务中心</h1>
+        <p>统一处理待办、查看已办，并追踪我发起的业务流程。</p>
+      </div>
+      <div class="hero-actions">
+        <v-btn variant="tonal" prepend-icon="mdi-cash-refund" @click="router.push('/expenses')">费用报销</v-btn>
+        <v-btn color="primary" prepend-icon="mdi-refresh" :loading="loading" @click="fetchTasks">刷新</v-btn>
+      </div>
+    </section>
+
+    <v-card class="filter-card" elevation="0">
+      <v-tabs v-model="filters.view" color="primary" grow>
+        <v-tab value="TODO">我的待办</v-tab>
+        <v-tab value="DONE">我的已办</v-tab>
+        <v-tab value="INITIATED">我发起的</v-tab>
+      </v-tabs>
+      <v-divider />
+      <v-card-text>
+        <v-row dense>
+          <v-col cols="12" md="3">
+            <v-text-field v-model.trim="filters.tenantId" label="租户" variant="outlined" density="comfortable" hide-details />
+          </v-col>
+          <v-col cols="12" md="3">
+            <v-text-field v-model.trim="filters.businessType" label="业务类型" variant="outlined" density="comfortable" hide-details clearable />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field
+              v-model.trim="filters.keyword"
+              label="任务、单据或发起人"
+              prepend-inner-icon="mdi-magnify"
+              variant="outlined"
+              density="comfortable"
+              hide-details
+              clearable
+              @keydown.enter="applyFilters"
+            />
+          </v-col>
+          <v-col cols="12" md="2" class="filter-actions">
+            <v-btn color="primary" block @click="applyFilters">查询</v-btn>
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-card>
+
+    <v-alert v-if="!operatorId" type="warning" variant="tonal" class="mb-4">
+      当前登录令牌中无法解析用户编号。任务查询仍可使用，但执行审批前需要重新登录或补充 userId。
+    </v-alert>
+
+    <v-card class="table-card" elevation="0">
+      <div class="table-heading">
+        <div>
+          <span>{{ viewTitle }}</span>
+          <strong>共 {{ total }} 条流程任务</strong>
+        </div>
+        <small>第 {{ page }} / {{ pageCount }} 页</small>
+      </div>
+
+      <v-data-table
+        :headers="headers"
+        :items="items"
+        :loading="loading"
+        :items-per-page="size"
+        item-value="taskId"
+        hide-default-footer
+        class="task-table"
+      >
+        <template #item.task="{ item }">
+          <div class="task-main">
+            <strong>{{ item.taskName || item.currentNodeKey || '流程任务' }}</strong>
+            <small>{{ item.taskId }}</small>
+          </div>
+        </template>
+
+        <template #item.business="{ item }">
+          <button class="business-link" type="button" @click="openBusiness(item)">
+            <strong>{{ businessTypeText(item.businessType) }}</strong>
+            <small>{{ item.businessId }}</small>
+          </button>
+        </template>
+
+        <template #item.initiatorId="{ item }">
+          <span>{{ item.initiatorId || '-' }}</span>
+        </template>
+
+        <template #item.status="{ item }">
+          <div class="status-stack">
+            <v-chip size="small" variant="tonal" :color="statusColor(item.taskStatus)">{{ item.taskStatus || '-' }}</v-chip>
+            <small>流程：{{ item.instanceStatus || '-' }}</small>
+          </div>
+        </template>
+
+        <template #item.createdAt="{ item }">
+          {{ formatTime(item.createdAt || item.completedAt) }}
+        </template>
+
+        <template #item.actions="{ item }">
+          <div v-if="filters.view === 'TODO'" class="row-actions">
+            <v-btn size="small" color="success" variant="tonal" @click="openAction(item, 'APPROVE')">通过</v-btn>
+            <v-btn size="small" color="error" variant="tonal" @click="openAction(item, 'REJECT')">驳回</v-btn>
+            <v-btn size="small" variant="tonal" @click="openAction(item, 'RETURN_TO_INITIATOR')">退回</v-btn>
+          </div>
+          <v-btn v-else size="small" variant="text" @click="openBusiness(item)">查看业务</v-btn>
+        </template>
+
+        <template #no-data>
+          <div class="empty-state">
+            <v-icon size="42">mdi-clipboard-check-outline</v-icon>
+            <strong>当前视图暂无任务</strong>
+            <span>调整筛选条件或刷新后重试。</span>
+          </div>
+        </template>
+      </v-data-table>
+
+      <div class="pagination-bar">
+        <v-pagination v-model="page" :length="pageCount" :total-visible="7" @update:model-value="fetchTasks" />
+      </div>
+    </v-card>
+
+    <v-dialog v-model="actionDialog.visible" max-width="560" persistent>
+      <v-card>
+        <v-card-title>{{ actionText(actionDialog.action) }}任务</v-card-title>
+        <v-card-text>
+          <v-alert variant="tonal" type="info" class="mb-4">
+            {{ actionDialog.task?.taskName }} · {{ actionDialog.task?.businessId }}
+          </v-alert>
+          <v-text-field v-model="operatorId" label="操作人" variant="outlined" :disabled="Boolean(getCurrentUserId())" />
+          <v-textarea v-model="actionDialog.comment" label="处理意见" variant="outlined" rows="4" auto-grow />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeAction">取消</v-btn>
+          <v-btn :color="actionColor(actionDialog.action)" :loading="actionDialog.loading" @click="submitAction">确认{{ actionText(actionDialog.action) }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="2200">{{ snackbar.text }}</v-snackbar>
+  </main>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { actOnWorkflowTask, listWorkflowTaskCenter } from '@/api/workflow'
+import { getCurrentUserId } from '@/utils/currentUser'
+
+const router = useRouter()
+const loading = ref(false)
+const items = ref([])
+const total = ref(0)
+const page = ref(1)
+const size = ref(20)
+const operatorId = ref(getCurrentUserId())
+
+const filters = reactive({
+  tenantId: 'default',
+  view: 'TODO',
+  businessType: '',
+  keyword: '',
+})
+
+const headers = [
+  { title: '任务', key: 'task', minWidth: 210 },
+  { title: '业务单据', key: 'business', minWidth: 190 },
+  { title: '发起人', key: 'initiatorId', width: 130 },
+  { title: '状态', key: 'status', width: 150 },
+  { title: '创建/完成时间', key: 'createdAt', width: 170 },
+  { title: '操作', key: 'actions', sortable: false, minWidth: 220 },
+]
+
+const actionDialog = reactive({
+  visible: false,
+  loading: false,
+  task: null,
+  action: 'APPROVE',
+  comment: '',
+})
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+
+const pageCount = computed(() => Math.max(1, Math.ceil(total.value / size.value)))
+const viewTitle = computed(() => ({ TODO: '我的待办', DONE: '我的已办', INITIATED: '我发起的' }[filters.view] || '流程任务'))
+
+watch(() => filters.view, () => {
+  page.value = 1
+  fetchTasks()
+})
+
+onMounted(fetchTasks)
+
+async function fetchTasks() {
+  if (!filters.tenantId) {
+    showMessage('租户不能为空', 'warning')
+    return
+  }
+  loading.value = true
+  try {
+    const response = await listWorkflowTaskCenter({
+      tenantId: filters.tenantId,
+      view: filters.view,
+      businessType: filters.businessType || undefined,
+      keyword: filters.keyword || undefined,
+      page: page.value,
+      size: size.value,
+    })
+    const data = response?.data || {}
+    items.value = Array.isArray(data.items) ? data.items : []
+    total.value = Number(data.total || 0)
+  } catch (error) {
+    items.value = []
+    total.value = 0
+    showMessage(error?.response?.data?.message || '工作流任务加载失败', 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+function applyFilters() {
+  page.value = 1
+  fetchTasks()
+}
+
+function openAction(task, action) {
+  actionDialog.task = task
+  actionDialog.action = action
+  actionDialog.comment = ''
+  actionDialog.visible = true
+}
+
+function closeAction() {
+  if (actionDialog.loading) return
+  actionDialog.visible = false
+  actionDialog.task = null
+}
+
+async function submitAction() {
+  if (!operatorId.value) {
+    showMessage('无法识别当前操作人，请重新登录', 'warning')
+    return
+  }
+  actionDialog.loading = true
+  try {
+    await actOnWorkflowTask(actionDialog.task.taskId, {
+      action: actionDialog.action,
+      operatorId: operatorId.value,
+      comment: actionDialog.comment || undefined,
+      variables: {},
+    })
+    showMessage(`任务已${actionText(actionDialog.action)}`)
+    closeAction()
+    await fetchTasks()
+  } catch (error) {
+    showMessage(error?.response?.data?.message || '任务处理失败', 'error')
+  } finally {
+    actionDialog.loading = false
+  }
+}
+
+function openBusiness(item) {
+  if ((item.businessType || '').toUpperCase().includes('EXPENSE') && item.businessId) {
+    router.push({ path: '/expenses', query: { expenseId: item.businessId } })
+    return
+  }
+  showMessage('该业务详情页尚未接入', 'info')
+}
+
+function businessTypeText(value) {
+  if (!value) return '业务流程'
+  if (value.toUpperCase().includes('EXPENSE')) return '费用报销'
+  return value
+}
+
+function statusColor(value) {
+  const status = (value || '').toUpperCase()
+  if (['COMPLETED', 'APPROVED', 'DONE'].includes(status)) return 'success'
+  if (['REJECTED', 'CANCELLED', 'FAILED'].includes(status)) return 'error'
+  if (['PENDING', 'TODO', 'ACTIVE', 'PROCESSING'].includes(status)) return 'primary'
+  return 'default'
+}
+
+function actionText(action) {
+  return ({ APPROVE: '通过', REJECT: '驳回', RETURN_TO_INITIATOR: '退回发起人' }[action] || action)
+}
+
+function actionColor(action) {
+  return action === 'APPROVE' ? 'success' : action === 'REJECT' ? 'error' : 'warning'
+}
+
+function formatTime(value) {
+  if (!value) return '-'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('zh-CN', { hour12: false })
+}
+
+function showMessage(text, color = 'success') {
+  snackbar.text = text
+  snackbar.color = color
+  snackbar.show = true
+}
+</script>
+
+<style scoped>
+.workflow-page {
+  min-height: 100vh;
+  padding: 30px;
+  color: #20322f;
+  background: #f4f7f6;
+}
+.hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 22px;
+  padding: 30px 34px;
+  border-radius: 24px;
+  color: white;
+  background: linear-gradient(135deg, #1d6455, #378d73);
+}
+.hero span { font-size: 11px; font-weight: 800; letter-spacing: .16em; opacity: .75; }
+.hero h1 { margin: 8px 0 0; font-size: 36px; }
+.hero p { margin: 12px 0 0; opacity: .78; }
+.hero-actions { display: flex; gap: 10px; }
+.filter-card,
+.table-card { border: 1px solid #dfe8e5; border-radius: 18px; background: white; }
+.filter-card { margin-bottom: 18px; }
+.filter-actions { display: flex; align-items: center; }
+.table-heading { display: flex; align-items: center; justify-content: space-between; padding: 20px 22px 12px; }
+.table-heading span,
+.table-heading strong { display: block; }
+.table-heading span { color: #71837e; font-size: 11px; text-transform: uppercase; letter-spacing: .12em; }
+.table-heading strong { margin-top: 5px; font-size: 18px; }
+.table-heading small { color: #82928e; }
+.task-main,
+.business-link,
+.status-stack { display: grid; gap: 4px; }
+.task-main small,
+.business-link small,
+.status-stack small { color: #83928e; font-size: 11px; }
+.business-link { padding: 0; border: 0; color: #236d5a; background: transparent; cursor: pointer; text-align: left; }
+.row-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+.pagination-bar { display: flex; justify-content: center; padding: 14px 20px 22px; }
+.empty-state { display: grid; justify-items: center; gap: 8px; padding: 48px; color: #81918d; }
+.empty-state strong { color: #435b55; }
+@media (max-width: 800px) {
+  .workflow-page { padding: 16px; }
+  .hero { align-items: flex-start; flex-direction: column; padding: 24px; }
+  .hero h1 { font-size: 28px; }
+  .hero-actions { width: 100%; flex-wrap: wrap; }
+}
+</style>

--- a/src/views/login/workflow/WorkflowTaskCenterView.vue
+++ b/src/views/login/workflow/WorkflowTaskCenterView.vue
@@ -21,27 +21,12 @@
       <v-divider />
       <v-card-text>
         <v-row dense>
-          <v-col cols="12" md="3">
-            <v-text-field v-model.trim="filters.tenantId" label="租户" variant="outlined" density="comfortable" hide-details />
-          </v-col>
-          <v-col cols="12" md="3">
-            <v-text-field v-model.trim="filters.businessType" label="业务类型" variant="outlined" density="comfortable" hide-details clearable />
-          </v-col>
+          <v-col cols="12" md="3"><v-text-field v-model.trim="filters.tenantId" label="租户" variant="outlined" density="comfortable" hide-details /></v-col>
+          <v-col cols="12" md="3"><v-text-field v-model.trim="filters.businessType" label="业务类型" variant="outlined" density="comfortable" hide-details clearable /></v-col>
           <v-col cols="12" md="4">
-            <v-text-field
-              v-model.trim="filters.keyword"
-              label="任务、单据或发起人"
-              prepend-inner-icon="mdi-magnify"
-              variant="outlined"
-              density="comfortable"
-              hide-details
-              clearable
-              @keydown.enter="applyFilters"
-            />
+            <v-text-field v-model.trim="filters.keyword" label="任务、单据或发起人" prepend-inner-icon="mdi-magnify" variant="outlined" density="comfortable" hide-details clearable @keydown.enter="applyFilters" />
           </v-col>
-          <v-col cols="12" md="2" class="filter-actions">
-            <v-btn color="primary" block @click="applyFilters">查询</v-btn>
-          </v-col>
+          <v-col cols="12" md="2" class="filter-actions"><v-btn color="primary" block @click="applyFilters">查询</v-btn></v-col>
         </v-row>
       </v-card-text>
     </v-card>
@@ -52,51 +37,18 @@
 
     <v-card class="table-card" elevation="0">
       <div class="table-heading">
-        <div>
-          <span>{{ viewTitle }}</span>
-          <strong>共 {{ total }} 条流程任务</strong>
-        </div>
+        <div><span>{{ viewTitle }}</span><strong>共 {{ total }} 条流程任务</strong></div>
         <small>第 {{ page }} / {{ pageCount }} 页</small>
       </div>
 
-      <v-data-table
-        :headers="headers"
-        :items="items"
-        :loading="loading"
-        :items-per-page="size"
-        item-value="taskId"
-        hide-default-footer
-        class="task-table"
-      >
-        <template #item.task="{ item }">
-          <div class="task-main">
-            <strong>{{ item.taskName || item.currentNodeKey || '流程任务' }}</strong>
-            <small>{{ item.taskId }}</small>
-          </div>
-        </template>
-
+      <v-data-table :headers="headers" :items="items" :loading="loading" :items-per-page="size" item-value="taskId" hide-default-footer>
+        <template #item.task="{ item }"><div class="primary-cell"><strong>{{ item.taskName || item.currentNodeKey || '流程任务' }}</strong><small>{{ item.taskId }}</small></div></template>
         <template #item.business="{ item }">
-          <button class="business-link" type="button" @click="openBusiness(item)">
-            <strong>{{ businessTypeText(item.businessType) }}</strong>
-            <small>{{ item.businessId }}</small>
-          </button>
+          <button class="business-link" type="button" @click="openBusiness(item)"><strong>{{ businessTypeText(item.businessType) }}</strong><small>{{ item.businessId }}</small></button>
         </template>
-
-        <template #item.initiatorId="{ item }">
-          <span>{{ item.initiatorId || '-' }}</span>
-        </template>
-
-        <template #item.status="{ item }">
-          <div class="status-stack">
-            <v-chip size="small" variant="tonal" :color="statusColor(item.taskStatus)">{{ item.taskStatus || '-' }}</v-chip>
-            <small>流程：{{ item.instanceStatus || '-' }}</small>
-          </div>
-        </template>
-
-        <template #item.createdAt="{ item }">
-          {{ formatTime(item.createdAt || item.completedAt) }}
-        </template>
-
+        <template #item.initiatorId="{ item }">{{ item.initiatorId || '-' }}</template>
+        <template #item.status="{ item }"><div class="status-stack"><v-chip size="small" variant="tonal" :color="statusColor(item.taskStatus)">{{ item.taskStatus || '-' }}</v-chip><small>流程：{{ item.instanceStatus || '-' }}</small></div></template>
+        <template #item.createdAt="{ item }">{{ formatTime(item.createdAt || item.completedAt) }}</template>
         <template #item.actions="{ item }">
           <div v-if="filters.view === 'TODO'" class="row-actions">
             <v-btn size="small" color="success" variant="tonal" @click="openAction(item, 'APPROVE')">通过</v-btn>
@@ -105,36 +57,21 @@
           </div>
           <v-btn v-else size="small" variant="text" @click="openBusiness(item)">查看业务</v-btn>
         </template>
-
-        <template #no-data>
-          <div class="empty-state">
-            <v-icon size="42">mdi-clipboard-check-outline</v-icon>
-            <strong>当前视图暂无任务</strong>
-            <span>调整筛选条件或刷新后重试。</span>
-          </div>
-        </template>
+        <template #no-data><div class="empty-state"><v-icon size="42">mdi-clipboard-check-outline</v-icon><strong>当前视图暂无任务</strong><span>调整筛选条件或刷新后重试。</span></div></template>
       </v-data-table>
 
-      <div class="pagination-bar">
-        <v-pagination v-model="page" :length="pageCount" :total-visible="7" @update:model-value="fetchTasks" />
-      </div>
+      <div class="pagination-bar"><v-pagination v-model="page" :length="pageCount" :total-visible="7" @update:model-value="fetchTasks" /></div>
     </v-card>
 
     <v-dialog v-model="actionDialog.visible" max-width="560" persistent>
       <v-card>
         <v-card-title>{{ actionText(actionDialog.action) }}任务</v-card-title>
         <v-card-text>
-          <v-alert variant="tonal" type="info" class="mb-4">
-            {{ actionDialog.task?.taskName }} · {{ actionDialog.task?.businessId }}
-          </v-alert>
-          <v-text-field v-model="operatorId" label="操作人" variant="outlined" :disabled="Boolean(getCurrentUserId())" />
+          <v-alert variant="tonal" type="info" class="mb-4">{{ actionDialog.task?.taskName }} · {{ actionDialog.task?.businessId }}</v-alert>
+          <v-text-field v-model="operatorId" label="操作人" variant="outlined" :disabled="Boolean(resolvedUserId)" />
           <v-textarea v-model="actionDialog.comment" label="处理意见" variant="outlined" rows="4" auto-grow />
         </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn variant="text" @click="closeAction">取消</v-btn>
-          <v-btn :color="actionColor(actionDialog.action)" :loading="actionDialog.loading" @click="submitAction">确认{{ actionText(actionDialog.action) }}</v-btn>
-        </v-card-actions>
+        <v-card-actions><v-spacer /><v-btn variant="text" :disabled="actionDialog.loading" @click="closeAction">取消</v-btn><v-btn :color="actionColor(actionDialog.action)" :loading="actionDialog.loading" @click="submitAction">确认{{ actionText(actionDialog.action) }}</v-btn></v-card-actions>
       </v-card>
     </v-dialog>
 
@@ -149,19 +86,16 @@ import { actOnWorkflowTask, listWorkflowTaskCenter } from '@/api/workflow'
 import { getCurrentUserId } from '@/utils/currentUser'
 
 const router = useRouter()
+const resolvedUserId = getCurrentUserId()
+const operatorId = ref(resolvedUserId)
 const loading = ref(false)
 const items = ref([])
 const total = ref(0)
 const page = ref(1)
 const size = ref(20)
-const operatorId = ref(getCurrentUserId())
-
-const filters = reactive({
-  tenantId: 'default',
-  view: 'TODO',
-  businessType: '',
-  keyword: '',
-})
+const filters = reactive({ tenantId: 'default', view: 'TODO', businessType: '', keyword: '' })
+const snackbar = reactive({ show: false, text: '', color: 'success' })
+const actionDialog = reactive({ visible: false, loading: false, task: null, action: 'APPROVE', comment: '' })
 
 const headers = [
   { title: '任务', key: 'task', minWidth: 210 },
@@ -171,41 +105,17 @@ const headers = [
   { title: '创建/完成时间', key: 'createdAt', width: 170 },
   { title: '操作', key: 'actions', sortable: false, minWidth: 220 },
 ]
-
-const actionDialog = reactive({
-  visible: false,
-  loading: false,
-  task: null,
-  action: 'APPROVE',
-  comment: '',
-})
-const snackbar = reactive({ show: false, text: '', color: 'success' })
-
 const pageCount = computed(() => Math.max(1, Math.ceil(total.value / size.value)))
 const viewTitle = computed(() => ({ TODO: '我的待办', DONE: '我的已办', INITIATED: '我发起的' }[filters.view] || '流程任务'))
 
-watch(() => filters.view, () => {
-  page.value = 1
-  fetchTasks()
-})
-
+watch(() => filters.view, () => { page.value = 1; fetchTasks() })
 onMounted(fetchTasks)
 
 async function fetchTasks() {
-  if (!filters.tenantId) {
-    showMessage('租户不能为空', 'warning')
-    return
-  }
+  if (!filters.tenantId) return showMessage('租户不能为空', 'warning')
   loading.value = true
   try {
-    const response = await listWorkflowTaskCenter({
-      tenantId: filters.tenantId,
-      view: filters.view,
-      businessType: filters.businessType || undefined,
-      keyword: filters.keyword || undefined,
-      page: page.value,
-      size: size.value,
-    })
+    const response = await listWorkflowTaskCenter({ tenantId: filters.tenantId, view: filters.view, businessType: filters.businessType || undefined, keyword: filters.keyword || undefined, page: page.value, size: size.value })
     const data = response?.data || {}
     items.value = Array.isArray(data.items) ? data.items : []
     total.value = Number(data.total || 0)
@@ -218,38 +128,17 @@ async function fetchTasks() {
   }
 }
 
-function applyFilters() {
-  page.value = 1
-  fetchTasks()
-}
-
-function openAction(task, action) {
-  actionDialog.task = task
-  actionDialog.action = action
-  actionDialog.comment = ''
-  actionDialog.visible = true
-}
-
-function closeAction() {
-  if (actionDialog.loading) return
-  actionDialog.visible = false
-  actionDialog.task = null
-}
+function applyFilters() { page.value = 1; fetchTasks() }
+function openAction(task, action) { actionDialog.task = task; actionDialog.action = action; actionDialog.comment = ''; actionDialog.visible = true }
+function closeAction() { actionDialog.visible = false; actionDialog.task = null; actionDialog.comment = '' }
 
 async function submitAction() {
-  if (!operatorId.value) {
-    showMessage('无法识别当前操作人，请重新登录', 'warning')
-    return
-  }
+  if (!operatorId.value) return showMessage('无法识别当前操作人，请重新登录', 'warning')
   actionDialog.loading = true
   try {
-    await actOnWorkflowTask(actionDialog.task.taskId, {
-      action: actionDialog.action,
-      operatorId: operatorId.value,
-      comment: actionDialog.comment || undefined,
-      variables: {},
-    })
+    await actOnWorkflowTask(actionDialog.task.taskId, { action: actionDialog.action, operatorId: operatorId.value, comment: actionDialog.comment || undefined, variables: {} })
     showMessage(`任务已${actionText(actionDialog.action)}`)
+    actionDialog.loading = false
     closeAction()
     await fetchTasks()
   } catch (error) {
@@ -260,95 +149,24 @@ async function submitAction() {
 }
 
 function openBusiness(item) {
-  if ((item.businessType || '').toUpperCase().includes('EXPENSE') && item.businessId) {
-    router.push({ path: '/expenses', query: { expenseId: item.businessId } })
-    return
-  }
+  if ((item.businessType || '').toUpperCase().includes('EXPENSE') && item.businessId) return router.push({ path: '/expenses', query: { expenseId: item.businessId } })
   showMessage('该业务详情页尚未接入', 'info')
 }
-
-function businessTypeText(value) {
-  if (!value) return '业务流程'
-  if (value.toUpperCase().includes('EXPENSE')) return '费用报销'
-  return value
-}
-
-function statusColor(value) {
-  const status = (value || '').toUpperCase()
-  if (['COMPLETED', 'APPROVED', 'DONE'].includes(status)) return 'success'
-  if (['REJECTED', 'CANCELLED', 'FAILED'].includes(status)) return 'error'
-  if (['PENDING', 'TODO', 'ACTIVE', 'PROCESSING'].includes(status)) return 'primary'
-  return 'default'
-}
-
-function actionText(action) {
-  return ({ APPROVE: '通过', REJECT: '驳回', RETURN_TO_INITIATOR: '退回发起人' }[action] || action)
-}
-
-function actionColor(action) {
-  return action === 'APPROVE' ? 'success' : action === 'REJECT' ? 'error' : 'warning'
-}
-
-function formatTime(value) {
-  if (!value) return '-'
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('zh-CN', { hour12: false })
-}
-
-function showMessage(text, color = 'success') {
-  snackbar.text = text
-  snackbar.color = color
-  snackbar.show = true
-}
+function businessTypeText(value) { if (!value) return '业务流程'; return value.toUpperCase().includes('EXPENSE') ? '费用报销' : value }
+function statusColor(value) { const status = (value || '').toUpperCase(); if (['COMPLETED', 'APPROVED', 'DONE'].includes(status)) return 'success'; if (['REJECTED', 'CANCELLED', 'FAILED'].includes(status)) return 'error'; if (['PENDING', 'TODO', 'ACTIVE', 'PROCESSING'].includes(status)) return 'primary'; return 'default' }
+function actionText(action) { return ({ APPROVE: '通过', REJECT: '驳回', RETURN_TO_INITIATOR: '退回发起人' }[action] || action) }
+function actionColor(action) { return action === 'APPROVE' ? 'success' : action === 'REJECT' ? 'error' : 'warning' }
+function formatTime(value) { if (!value) return '-'; const date = new Date(value); return Number.isNaN(date.getTime()) ? value : date.toLocaleString('zh-CN', { hour12: false }) }
+function showMessage(text, color = 'success') { snackbar.text = text; snackbar.color = color; snackbar.show = true }
 </script>
 
 <style scoped>
-.workflow-page {
-  min-height: 100vh;
-  padding: 30px;
-  color: #20322f;
-  background: #f4f7f6;
-}
-.hero {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 24px;
-  margin-bottom: 22px;
-  padding: 30px 34px;
-  border-radius: 24px;
-  color: white;
-  background: linear-gradient(135deg, #1d6455, #378d73);
-}
-.hero span { font-size: 11px; font-weight: 800; letter-spacing: .16em; opacity: .75; }
-.hero h1 { margin: 8px 0 0; font-size: 36px; }
-.hero p { margin: 12px 0 0; opacity: .78; }
-.hero-actions { display: flex; gap: 10px; }
-.filter-card,
-.table-card { border: 1px solid #dfe8e5; border-radius: 18px; background: white; }
-.filter-card { margin-bottom: 18px; }
-.filter-actions { display: flex; align-items: center; }
-.table-heading { display: flex; align-items: center; justify-content: space-between; padding: 20px 22px 12px; }
-.table-heading span,
-.table-heading strong { display: block; }
-.table-heading span { color: #71837e; font-size: 11px; text-transform: uppercase; letter-spacing: .12em; }
-.table-heading strong { margin-top: 5px; font-size: 18px; }
-.table-heading small { color: #82928e; }
-.task-main,
-.business-link,
-.status-stack { display: grid; gap: 4px; }
-.task-main small,
-.business-link small,
-.status-stack small { color: #83928e; font-size: 11px; }
-.business-link { padding: 0; border: 0; color: #236d5a; background: transparent; cursor: pointer; text-align: left; }
-.row-actions { display: flex; flex-wrap: wrap; gap: 6px; }
-.pagination-bar { display: flex; justify-content: center; padding: 14px 20px 22px; }
-.empty-state { display: grid; justify-items: center; gap: 8px; padding: 48px; color: #81918d; }
-.empty-state strong { color: #435b55; }
-@media (max-width: 800px) {
-  .workflow-page { padding: 16px; }
-  .hero { align-items: flex-start; flex-direction: column; padding: 24px; }
-  .hero h1 { font-size: 28px; }
-  .hero-actions { width: 100%; flex-wrap: wrap; }
-}
+.workflow-page { min-height: 100vh; padding: 30px; color: #20322f; background: #f4f7f6; }
+.hero { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 22px; padding: 30px 34px; border-radius: 24px; color: white; background: linear-gradient(135deg, #1d6455, #378d73); }
+.hero span { font-size: 11px; font-weight: 800; letter-spacing: .16em; opacity: .75; }.hero h1 { margin: 8px 0 0; font-size: 36px; }.hero p { margin: 12px 0 0; opacity: .78; }.hero-actions { display: flex; gap: 10px; }
+.filter-card, .table-card { border: 1px solid #dfe8e5; border-radius: 18px; background: white; }.filter-card { margin-bottom: 18px; }.filter-actions { display: flex; align-items: center; }
+.table-heading { display: flex; align-items: center; justify-content: space-between; padding: 20px 22px 12px; }.table-heading span, .table-heading strong { display: block; }.table-heading span { color: #71837e; font-size: 11px; letter-spacing: .12em; }.table-heading strong { margin-top: 5px; font-size: 18px; }.table-heading small { color: #82928e; }
+.primary-cell, .business-link, .status-stack { display: grid; gap: 4px; }.primary-cell small, .business-link small, .status-stack small { color: #83928e; font-size: 11px; }.business-link { padding: 0; border: 0; color: #236d5a; background: transparent; cursor: pointer; text-align: left; }.row-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+.pagination-bar { display: flex; justify-content: center; padding: 14px 20px 22px; }.empty-state { display: grid; justify-items: center; gap: 8px; padding: 48px; color: #81918d; }.empty-state strong { color: #435b55; }
+@media (max-width: 800px) { .workflow-page { padding: 16px; }.hero { align-items: flex-start; flex-direction: column; padding: 24px; }.hero h1 { font-size: 28px; }.hero-actions { width: 100%; flex-wrap: wrap; } }
 </style>


### PR DESCRIPTION
## What changed

- add a real workflow task center with TODO, DONE, and INITIATED views
- support approve, reject, and return-to-initiator task actions
- add an expense reimbursement workspace backed by the existing finance workflow APIs
- support expense draft creation, lookup, editing, submission, cancellation, and approval details
- split Workflow, Expense Reimbursement, and Shared Operations into separate application-center entries
- split IM Management from the personal Notification Center
- add IM application, secret rotation, channel, and message-template management
- redirect legacy placeholder routes to existing real pages
- activate the redesigned application center and add targeted frontend CI

## Route changes

- `/workflow/tasks` — workflow task center
- `/expense-reimbursements` — expense reimbursement workspace
- `/expenses` — redirects to `/expense-reimbursements`
- `/im/management` — IM platform management
- `/notifications` — remains the personal message center

Legacy finance placeholder routes now redirect to the corresponding payable, receivable, report, workflow, or expense pages.

## Validation

A dedicated GitHub Actions workflow runs `npm ci` and `npm run build` for these paths.

## Target

Merge into `dev`. This branch also contains the application-center redesign that was previously isolated in PR #51.