### PR TITLE
feat: close expense and shared operations P0 gaps

### DIFF
--- a/.github/workflows/p0-business-closure-ci.yml
+++ b/.github/workflows/p0-business-closure-ci.yml
@@ -1,0 +1,47 @@
+name: P0 Business Closure Web CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - 'src/views/login/expense/**'
+      - 'src/views/login/workflow/**'
+      - 'src/views/login/shared/**'
+      - 'src/api/expense.js'
+      - 'src/api/workflow.js'
+      - 'src/api/workflowAttachment.js'
+      - 'src/api/sharedOperations.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/p0-business-closure-ci.yml'
+  push:
+    branches:
+      - 'feature/p0-expense-shared-*'
+    paths:
+      - 'src/views/login/expense/**'
+      - 'src/views/login/workflow/**'
+      - 'src/views/login/shared/**'
+      - 'src/api/workflowAttachment.js'
+      - 'src/api/sharedOperations.js'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build

--- a/src/api/sharedOperations.js
+++ b/src/api/sharedOperations.js
@@ -1,0 +1,43 @@
+import request from '@/utils/request'
+
+const BASE = '/shared-cloud'
+
+export function listSharedTasks(params = {}) {
+  return request.get(`${BASE}/tasks`, { params })
+}
+
+export function createSharedTask(data) {
+  return request.post(`${BASE}/tasks`, data)
+}
+
+export function getSharedTask(id) {
+  return request.get(`${BASE}/tasks/${encodeURIComponent(id)}`)
+}
+
+export function updateSharedTask(id, data) {
+  return request.patch(`${BASE}/tasks/${encodeURIComponent(id)}`, data)
+}
+
+export function deleteSharedTask(id) {
+  return request.delete(`${BASE}/tasks/${encodeURIComponent(id)}`)
+}
+
+export function transitionSharedTask(id, data) {
+  return request.post(`${BASE}/tasks/${encodeURIComponent(id)}/transitions`, data)
+}
+
+export function listSharedTaskComments(id, params = {}) {
+  return request.get(`${BASE}/tasks/${encodeURIComponent(id)}/comments`, { params })
+}
+
+export function addSharedTaskComment(id, data) {
+  return request.post(`${BASE}/tasks/${encodeURIComponent(id)}/comments`, data)
+}
+
+export function getSharedTaskSla(id) {
+  return request.get(`${BASE}/tasks/${encodeURIComponent(id)}/sla`)
+}
+
+export function getSharedOperationsSummary(params = {}) {
+  return request.get(`${BASE}/report/summary`, { params })
+}

--- a/src/api/workflowAttachment.js
+++ b/src/api/workflowAttachment.js
@@ -1,0 +1,30 @@
+import request from '@/utils/request'
+
+export function requestWorkflowUpload(data) {
+  return request.post('/workflow/files/upload-url', data)
+}
+
+export function uploadWorkflowContent(uploadUrl, file) {
+  return request.put(uploadUrl, file, {
+    headers: {
+      'Content-Type': file.type || 'application/octet-stream',
+    },
+  })
+}
+
+export function confirmWorkflowUpload(fileId, data) {
+  return request.post(`/workflow/files/${encodeURIComponent(fileId)}/confirm`, data)
+}
+
+export function listWorkflowBusinessAttachments({ tenantId, sourceSystem, businessType, businessId }) {
+  return request.get(
+    `/workflow/files/business/${encodeURIComponent(sourceSystem)}/${encodeURIComponent(businessType)}/${encodeURIComponent(businessId)}`,
+    { params: { tenantId } },
+  )
+}
+
+export function deleteWorkflowAttachment(relationId, operatorId) {
+  return request.delete(`/workflow/files/relations/${encodeURIComponent(relationId)}`, {
+    params: { operatorId },
+  })
+}

--- a/src/views/login/expense/ExpenseReimbursementView.vue
+++ b/src/views/login/expense/ExpenseReimbursementView.vue
@@ -4,7 +4,7 @@
       <div>
         <span>EXPENSE REIMBURSEMENT</span>
         <h1>费用报销</h1>
-        <p>创建报销单、提交审批，并追踪财务单据与工作流状态。</p>
+        <p>创建报销草稿、上传发票影像、提交或重新提交审批，并追踪完整流程。</p>
       </div>
       <div class="hero-actions">
         <v-btn variant="tonal" prepend-icon="mdi-format-list-checks" @click="router.push('/workflow/tasks')">流程任务</v-btn>
@@ -12,68 +12,42 @@
       </div>
     </section>
 
+    <v-alert v-if="isReturned" type="warning" variant="tonal" class="mb-4">
+      该报销单已被退回。请修改单据信息或发票附件后重新提交审批。
+    </v-alert>
+
     <section class="workspace-grid">
-      <v-card class="create-card" elevation="0">
+      <v-card class="panel-card" elevation="0">
         <v-card-title>新建报销单</v-card-title>
-        <v-card-subtitle>当前后端暂未提供报销单列表，请通过单据 ID 或流程中心追踪已发起记录。</v-card-subtitle>
+        <v-card-subtitle>保存草稿后上传至少一份发票影像，才能提交审批。</v-card-subtitle>
         <v-card-text>
           <v-form ref="createFormRef">
             <v-row dense>
-              <v-col cols="12" md="6">
-                <v-text-field v-model.trim="createForm.tenantId" label="租户" variant="outlined" :rules="requiredRules" />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-text-field v-model.trim="createForm.applicantId" label="申请人编号" variant="outlined" :rules="requiredRules" />
-              </v-col>
-              <v-col cols="12" md="6">
-                <v-text-field v-model.trim="createForm.departmentCode" label="部门编码" variant="outlined" :rules="requiredRules" />
-              </v-col>
-              <v-col cols="12" md="3">
-                <v-text-field v-model.number="createForm.amount" label="金额" type="number" min="0.01" step="0.01" variant="outlined" :rules="amountRules" />
-              </v-col>
-              <v-col cols="12" md="3">
-                <v-select v-model="createForm.currency" label="币种" :items="currencyOptions" variant="outlined" />
-              </v-col>
-              <v-col cols="12">
-                <v-textarea v-model.trim="createForm.description" label="报销事由" variant="outlined" rows="4" auto-grow :rules="requiredRules" />
-              </v-col>
+              <v-col cols="12" md="6"><v-text-field v-model.trim="createForm.tenantId" label="租户" variant="outlined" :rules="requiredRules" /></v-col>
+              <v-col cols="12" md="6"><v-text-field v-model.trim="createForm.applicantId" label="申请人编号" variant="outlined" :rules="requiredRules" /></v-col>
+              <v-col cols="12" md="6"><v-text-field v-model.trim="createForm.departmentCode" label="部门编码" variant="outlined" :rules="requiredRules" /></v-col>
+              <v-col cols="12" md="3"><v-text-field v-model.number="createForm.amount" label="金额" type="number" min="0.01" step="0.01" variant="outlined" :rules="amountRules" /></v-col>
+              <v-col cols="12" md="3"><v-select v-model="createForm.currency" label="币种" :items="currencyOptions" variant="outlined" /></v-col>
+              <v-col cols="12"><v-textarea v-model.trim="createForm.description" label="报销事由" variant="outlined" rows="4" auto-grow :rules="requiredRules" /></v-col>
             </v-row>
           </v-form>
         </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn variant="text" @click="resetCreateForm">重置</v-btn>
-          <v-btn color="primary" :loading="creating" @click="createDocument">保存草稿</v-btn>
-        </v-card-actions>
+        <v-card-actions><v-spacer /><v-btn variant="text" @click="resetCreateForm">重置</v-btn><v-btn color="primary" :loading="creating" @click="createDocument">保存草稿</v-btn></v-card-actions>
       </v-card>
 
       <div class="detail-column">
         <v-card class="lookup-card" elevation="0">
-          <v-card-text>
-            <div class="lookup-row">
-              <v-text-field
-                v-model.trim="lookupId"
-                label="报销单 ID"
-                prepend-inner-icon="mdi-magnify"
-                variant="outlined"
-                density="comfortable"
-                hide-details
-                @keydown.enter="loadDocument"
-              />
-              <v-btn color="primary" :loading="loading" @click="loadDocument">查询</v-btn>
-            </div>
+          <v-card-text class="lookup-row">
+            <v-text-field v-model.trim="lookupId" label="报销单 ID" prepend-inner-icon="mdi-magnify" variant="outlined" density="comfortable" hide-details @keydown.enter="loadDocument" />
+            <v-btn color="primary" :loading="loading" @click="loadDocument">查询</v-btn>
           </v-card-text>
         </v-card>
 
-        <v-card v-if="document" class="detail-card" elevation="0">
+        <v-card v-if="document" class="panel-card" elevation="0">
           <div class="detail-heading">
-            <div>
-              <span>{{ document.documentNumber || document.id }}</span>
-              <h2>{{ document.description }}</h2>
-            </div>
+            <div><span>{{ document.documentNumber || document.id }}</span><h2>{{ document.description }}</h2></div>
             <v-chip :color="statusColor(document.status)" variant="tonal">{{ statusText(document.status) }}</v-chip>
           </div>
-
           <v-card-text>
             <div class="metric-grid">
               <article><span>金额</span><strong>{{ formatMoney(document.amount, document.currency) }}</strong></article>
@@ -81,118 +55,94 @@
               <article><span>部门</span><strong>{{ document.departmentCode }}</strong></article>
               <article><span>版本</span><strong>v{{ document.version }}</strong></article>
             </div>
-
             <v-list lines="two" density="comfortable" class="detail-list">
               <v-list-item title="报销单 ID" :subtitle="document.id" />
               <v-list-item title="工作流实例" :subtitle="document.workflowInstanceId || '尚未提交审批'" />
               <v-list-item title="创建时间" :subtitle="formatTime(document.createdAt)" />
               <v-list-item title="提交时间" :subtitle="formatTime(document.submittedAt)" />
-              <v-list-item title="完成时间" :subtitle="formatTime(document.completedAt)" />
             </v-list>
           </v-card-text>
-
           <v-card-actions class="detail-actions">
-            <v-btn v-if="isDraft" variant="tonal" prepend-icon="mdi-pencil" @click="openEdit">编辑</v-btn>
-            <v-btn v-if="isDraft" color="primary" prepend-icon="mdi-send" @click="openSubmit">提交审批</v-btn>
+            <v-btn v-if="canEdit" variant="tonal" prepend-icon="mdi-pencil" @click="openEdit">编辑</v-btn>
+            <v-btn v-if="canEdit" color="primary" prepend-icon="mdi-send" :disabled="!hasQualifiedInvoice" @click="openSubmit">
+              {{ isReturned ? '重新提交审批' : '提交审批' }}
+            </v-btn>
             <v-btn v-if="canCancel" color="error" variant="tonal" prepend-icon="mdi-cancel" @click="openCancel">取消单据</v-btn>
             <v-btn variant="text" prepend-icon="mdi-timeline-text" :loading="approvalLoading" @click="loadApprovalDetail">审批详情</v-btn>
           </v-card-actions>
+          <v-alert v-if="canEdit && !hasQualifiedInvoice" type="warning" variant="tonal" density="compact" class="action-alert">
+            提交前必须上传至少一份状态为“已确认、安全”的发票影像。
+          </v-alert>
         </v-card>
 
         <v-card v-else class="empty-card" elevation="0">
-          <v-icon size="48">mdi-receipt-text-outline</v-icon>
-          <strong>尚未选择报销单</strong>
-          <span>创建新草稿，或输入报销单 ID 查询。</span>
+          <v-icon size="48">mdi-receipt-text-outline</v-icon><strong>尚未选择报销单</strong><span>创建新草稿，或输入报销单 ID 查询。</span>
         </v-card>
       </div>
     </section>
 
-    <v-card v-if="approvalDetail" class="approval-card" elevation="0">
-      <div class="approval-heading">
-        <div>
-          <span>APPROVAL DETAIL</span>
-          <h2>审批与关联数据</h2>
-        </div>
-        <v-btn variant="text" icon="mdi-close" @click="approvalDetail = null" />
+    <v-card v-if="document" class="attachment-card" elevation="0">
+      <div class="section-heading">
+        <div><span>INVOICE ATTACHMENTS</span><h2>发票影像</h2><p>仅已上传并通过安全检查的 INVOICE 附件满足提交条件。</p></div>
+        <v-chip :color="hasQualifiedInvoice ? 'success' : 'warning'" variant="tonal">合格附件 {{ qualifiedInvoiceCount }} 份</v-chip>
       </div>
-      <v-row>
-        <v-col v-for="section in approvalSections" :key="section.key" cols="12" md="6">
-          <article class="json-panel">
-            <strong>{{ section.title }}</strong>
-            <pre>{{ prettyJson(section.value) }}</pre>
-          </article>
-        </v-col>
-      </v-row>
+      <v-card-text>
+        <div v-if="canEdit" class="upload-row">
+          <v-file-input v-model="selectedFiles" label="选择发票文件" accept="application/pdf,image/*" prepend-icon="mdi-paperclip" variant="outlined" density="comfortable" show-size hide-details />
+          <v-btn color="primary" prepend-icon="mdi-cloud-upload" :loading="uploading" :disabled="!selectedFile" @click="uploadInvoice">上传并确认</v-btn>
+        </div>
+        <v-progress-linear v-if="uploading" indeterminate color="primary" class="mb-4" />
+        <v-data-table :headers="attachmentHeaders" :items="attachments" :loading="attachmentsLoading" item-value="relationId" hide-default-footer>
+          <template #item.originalName="{ item }"><div class="file-cell"><v-icon>mdi-file-document-outline</v-icon><div><strong>{{ item.originalName }}</strong><small>{{ formatFileSize(item.fileSize) }}</small></div></div></template>
+          <template #item.categoryCode="{ item }"><v-chip size="small" variant="tonal">{{ item.categoryCode }}</v-chip></template>
+          <template #item.uploadStatus="{ item }"><v-chip size="small" :color="attachmentStatusColor(item)" variant="tonal">{{ attachmentStatusText(item) }}</v-chip></template>
+          <template #item.actions="{ item }"><div class="row-actions"><v-btn size="small" variant="text" @click="downloadAttachment(item)">查看</v-btn><v-btn v-if="canEdit" size="small" variant="text" color="error" @click="removeAttachment(item)">删除</v-btn></div></template>
+          <template #no-data><div class="table-empty">尚未上传发票影像</div></template>
+        </v-data-table>
+      </v-card-text>
+    </v-card>
+
+    <v-card v-if="approvalDetail" class="approval-card" elevation="0">
+      <div class="section-heading"><div><span>APPROVAL DETAIL</span><h2>审批与关联数据</h2></div><v-btn variant="text" icon="mdi-close" @click="approvalDetail = null" /></div>
+      <v-row><v-col v-for="section in approvalSections" :key="section.key" cols="12" md="6"><article class="json-panel"><strong>{{ section.title }}</strong><pre>{{ prettyJson(section.value) }}</pre></article></v-col></v-row>
     </v-card>
 
     <v-dialog v-model="editDialog.visible" max-width="720" persistent>
-      <v-card>
-        <v-card-title>编辑报销草稿</v-card-title>
-        <v-card-text>
-          <v-row dense>
-            <v-col cols="12" md="6"><v-text-field v-model="editDialog.form.operatorId" label="操作人" variant="outlined" /></v-col>
-            <v-col cols="12" md="6"><v-text-field v-model="editDialog.form.departmentCode" label="部门编码" variant="outlined" /></v-col>
-            <v-col cols="12" md="8"><v-text-field v-model.number="editDialog.form.amount" label="金额" type="number" min="0.01" step="0.01" variant="outlined" /></v-col>
-            <v-col cols="12" md="4"><v-select v-model="editDialog.form.currency" label="币种" :items="currencyOptions" variant="outlined" /></v-col>
-            <v-col cols="12"><v-textarea v-model="editDialog.form.description" label="报销事由" variant="outlined" rows="4" auto-grow /></v-col>
-          </v-row>
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn variant="text" @click="editDialog.visible = false">取消</v-btn>
-          <v-btn color="primary" :loading="editDialog.loading" @click="saveEdit">保存</v-btn>
-        </v-card-actions>
-      </v-card>
+      <v-card><v-card-title>{{ isReturned ? '修改退回报销单' : '编辑报销草稿' }}</v-card-title><v-card-text><v-row dense>
+        <v-col cols="12" md="6"><v-text-field v-model="editDialog.form.operatorId" label="操作人" variant="outlined" /></v-col>
+        <v-col cols="12" md="6"><v-text-field v-model="editDialog.form.departmentCode" label="部门编码" variant="outlined" /></v-col>
+        <v-col cols="12" md="8"><v-text-field v-model.number="editDialog.form.amount" label="金额" type="number" min="0.01" step="0.01" variant="outlined" /></v-col>
+        <v-col cols="12" md="4"><v-select v-model="editDialog.form.currency" label="币种" :items="currencyOptions" variant="outlined" /></v-col>
+        <v-col cols="12"><v-textarea v-model="editDialog.form.description" label="报销事由" variant="outlined" rows="4" auto-grow /></v-col>
+      </v-row></v-card-text><v-card-actions><v-spacer /><v-btn variant="text" @click="editDialog.visible = false">取消</v-btn><v-btn color="primary" :loading="editDialog.loading" @click="saveEdit">保存</v-btn></v-card-actions></v-card>
     </v-dialog>
 
     <v-dialog v-model="submitDialog.visible" max-width="560" persistent>
-      <v-card>
-        <v-card-title>提交费用报销</v-card-title>
-        <v-card-text>
-          <v-text-field v-model="submitDialog.operatorId" label="操作人" variant="outlined" />
-          <v-text-field v-model="submitDialog.definitionKey" label="流程定义" variant="outlined" hint="默认 expense-reimbursement" persistent-hint />
-          <v-textarea v-model="submitDialog.comment" label="提交说明" variant="outlined" rows="3" class="mt-3" />
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn variant="text" @click="submitDialog.visible = false">取消</v-btn>
-          <v-btn color="primary" :loading="submitDialog.loading" @click="submitDocument">确认提交</v-btn>
-        </v-card-actions>
-      </v-card>
+      <v-card><v-card-title>{{ isReturned ? '重新提交费用报销' : '提交费用报销' }}</v-card-title><v-card-text>
+        <v-alert type="success" variant="tonal" density="compact" class="mb-4">已检测到 {{ qualifiedInvoiceCount }} 份合格发票附件。</v-alert>
+        <v-text-field v-model="submitDialog.operatorId" label="操作人" variant="outlined" />
+        <v-text-field v-model="submitDialog.definitionKey" label="流程定义" variant="outlined" hint="默认 expense-reimbursement" persistent-hint />
+        <v-textarea v-model="submitDialog.comment" label="提交说明" variant="outlined" rows="3" class="mt-3" />
+      </v-card-text><v-card-actions><v-spacer /><v-btn variant="text" @click="submitDialog.visible = false">取消</v-btn><v-btn color="primary" :loading="submitDialog.loading" @click="submitDocument">确认{{ isReturned ? '重新' : '' }}提交</v-btn></v-card-actions></v-card>
     </v-dialog>
 
     <v-dialog v-model="cancelDialog.visible" max-width="520" persistent>
-      <v-card>
-        <v-card-title>取消费用报销</v-card-title>
-        <v-card-text>
-          <v-text-field v-model="cancelDialog.operatorId" label="操作人" variant="outlined" />
-          <v-textarea v-model="cancelDialog.reason" label="取消原因" variant="outlined" rows="3" />
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn variant="text" @click="cancelDialog.visible = false">返回</v-btn>
-          <v-btn color="error" :loading="cancelDialog.loading" @click="cancelDocument">确认取消</v-btn>
-        </v-card-actions>
-      </v-card>
+      <v-card><v-card-title>取消费用报销</v-card-title><v-card-text><v-text-field v-model="cancelDialog.operatorId" label="操作人" variant="outlined" /><v-textarea v-model="cancelDialog.reason" label="取消原因" variant="outlined" rows="3" /></v-card-text><v-card-actions><v-spacer /><v-btn variant="text" @click="cancelDialog.visible = false">返回</v-btn><v-btn color="error" :loading="cancelDialog.loading" @click="cancelDocument">确认取消</v-btn></v-card-actions></v-card>
     </v-dialog>
 
-    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="2400">{{ snackbar.text }}</v-snackbar>
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="3000">{{ snackbar.text }}</v-snackbar>
   </main>
 </template>
 
 <script setup>
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import {
-  cancelExpense,
-  createExpense,
-  getExpense,
-  getExpenseApprovalDetail,
-  submitExpense,
-  updateExpense,
-} from '@/api/expense'
+import { cancelExpense, createExpense, getExpense, getExpenseApprovalDetail, submitExpense, updateExpense } from '@/api/expense'
+import { confirmWorkflowUpload, deleteWorkflowAttachment, listWorkflowBusinessAttachments, requestWorkflowUpload, uploadWorkflowContent } from '@/api/workflowAttachment'
 import { getCurrentUserId } from '@/utils/currentUser'
 
+const SOURCE_SYSTEM = 'fi-service'
+const BUSINESS_TYPE = 'EXPENSE_REIMBURSEMENT'
 const route = useRoute()
 const router = useRouter()
 const currentUserId = getCurrentUserId()
@@ -203,56 +153,46 @@ const approvalLoading = ref(false)
 const lookupId = ref('')
 const document = ref(null)
 const approvalDetail = ref(null)
+const attachments = ref([])
+const attachmentsLoading = ref(false)
+const selectedFiles = ref([])
+const uploading = ref(false)
 const snackbar = reactive({ show: false, text: '', color: 'success' })
 
-const createForm = reactive({
-  tenantId: 'default',
-  applicantId: currentUserId,
-  departmentCode: '',
-  amount: null,
-  currency: 'CNY',
-  description: '',
-})
+const createForm = reactive({ tenantId: 'default', applicantId: currentUserId, departmentCode: '', amount: null, currency: 'CNY', description: '' })
 const editDialog = reactive({ visible: false, loading: false, form: {} })
-const submitDialog = reactive({
-  visible: false,
-  loading: false,
-  operatorId: currentUserId,
-  definitionKey: 'expense-reimbursement',
-  comment: '',
-})
+const submitDialog = reactive({ visible: false, loading: false, operatorId: currentUserId, definitionKey: 'expense-reimbursement', comment: '' })
 const cancelDialog = reactive({ visible: false, loading: false, operatorId: currentUserId, reason: '' })
-
 const requiredRules = [value => Boolean(String(value || '').trim()) || '此项不能为空']
 const amountRules = [value => Number(value) > 0 || '金额必须大于 0']
 const currencyOptions = ['CNY', 'USD', 'HKD', 'EUR', 'JPY']
+const attachmentHeaders = [
+  { title: '文件', key: 'originalName', minWidth: 260 },
+  { title: '类别', key: 'categoryCode', width: 120 },
+  { title: '状态', key: 'uploadStatus', width: 150 },
+  { title: '创建时间', key: 'createdAt', width: 180 },
+  { title: '操作', key: 'actions', width: 140, sortable: false },
+]
 
-const isDraft = computed(() => (document.value?.status || '').toUpperCase() === 'DRAFT')
-const canCancel = computed(() => !['COMPLETED', 'CANCELLED', 'REJECTED'].includes((document.value?.status || '').toUpperCase()))
-const approvalSections = computed(() => {
-  if (!approvalDetail.value) return []
-  return [
-    { key: 'binding', title: '流程绑定', value: approvalDetail.value.binding },
-    { key: 'workflow', title: '流程实例', value: approvalDetail.value.workflow },
-    { key: 'tasks', title: '审批任务', value: approvalDetail.value.tasks },
-    { key: 'timeline', title: '审批时间线', value: approvalDetail.value.timeline },
-    { key: 'attachments', title: '附件', value: approvalDetail.value.attachments },
-  ]
-})
+const status = computed(() => String(document.value?.status || '').toUpperCase())
+const canEdit = computed(() => ['DRAFT', 'RETURNED'].includes(status.value))
+const isReturned = computed(() => status.value === 'RETURNED')
+const canCancel = computed(() => ['APPROVING', 'RETURNED'].includes(status.value))
+const selectedFile = computed(() => Array.isArray(selectedFiles.value) ? selectedFiles.value[0] : selectedFiles.value)
+const qualifiedInvoiceCount = computed(() => attachments.value.filter(isQualifiedInvoice).length)
+const hasQualifiedInvoice = computed(() => qualifiedInvoiceCount.value > 0)
+const approvalSections = computed(() => approvalDetail.value ? [
+  { key: 'binding', title: '流程绑定', value: approvalDetail.value.binding },
+  { key: 'workflow', title: '流程实例', value: approvalDetail.value.workflow },
+  { key: 'tasks', title: '审批任务', value: approvalDetail.value.tasks },
+  { key: 'timeline', title: '审批时间线', value: approvalDetail.value.timeline },
+  { key: 'attachments', title: '附件', value: approvalDetail.value.attachments },
+] : [])
 
 watch(() => route.query.expenseId, value => {
-  if (typeof value === 'string' && value && value !== document.value?.id) {
-    lookupId.value = value
-    loadDocument()
-  }
+  if (typeof value === 'string' && value && value !== document.value?.id) { lookupId.value = value; loadDocument() }
 })
-
-onMounted(() => {
-  if (typeof route.query.expenseId === 'string' && route.query.expenseId) {
-    lookupId.value = route.query.expenseId
-    loadDocument()
-  }
-})
+onMounted(() => { if (typeof route.query.expenseId === 'string' && route.query.expenseId) { lookupId.value = route.query.expenseId; loadDocument() } })
 
 async function createDocument() {
   const validation = await createFormRef.value?.validate()
@@ -263,66 +203,92 @@ async function createDocument() {
     document.value = response?.data || null
     lookupId.value = document.value?.id || ''
     approvalDetail.value = null
+    attachments.value = []
     syncQuery()
-    showMessage('报销草稿已创建')
-  } catch (error) {
-    showMessage(error?.response?.data?.message || '报销单创建失败', 'error')
-  } finally {
-    creating.value = false
-  }
+    showMessage('报销草稿已创建，请继续上传发票影像')
+  } catch (error) { showMessage(apiMessage(error, '报销单创建失败'), 'error') } finally { creating.value = false }
 }
 
 async function loadDocument() {
-  if (!lookupId.value) {
-    showMessage('请输入报销单 ID', 'warning')
-    return
-  }
+  if (!lookupId.value) return showMessage('请输入报销单 ID', 'warning')
   loading.value = true
   try {
     const response = await getExpense(lookupId.value)
     document.value = response?.data || null
     approvalDetail.value = null
     syncQuery()
-  } catch (error) {
-    document.value = null
-    showMessage(error?.response?.data?.message || '报销单查询失败', 'error')
-  } finally {
-    loading.value = false
-  }
+    await loadAttachments()
+  } catch (error) { document.value = null; attachments.value = []; showMessage(apiMessage(error, '报销单查询失败'), 'error') } finally { loading.value = false }
+}
+
+async function loadAttachments() {
+  if (!document.value?.id) return
+  attachmentsLoading.value = true
+  try {
+    const response = await listWorkflowBusinessAttachments({ tenantId: document.value.tenantId, sourceSystem: SOURCE_SYSTEM, businessType: BUSINESS_TYPE, businessId: document.value.id })
+    attachments.value = Array.isArray(response?.data) ? response.data : []
+  } catch (error) { attachments.value = []; showMessage(apiMessage(error, '附件加载失败'), 'error') } finally { attachmentsLoading.value = false }
+}
+
+async function uploadInvoice() {
+  const file = selectedFile.value
+  if (!file || !document.value?.id) return
+  if (file.size > 50 * 1024 * 1024) return showMessage('单个附件不能超过 50MB', 'warning')
+  uploading.value = true
+  try {
+    const sha256 = await digestFile(file)
+    const requested = await requestWorkflowUpload({
+      tenantId: document.value.tenantId,
+      sourceSystem: SOURCE_SYSTEM,
+      businessType: BUSINESS_TYPE,
+      businessId: document.value.id,
+      instanceId: document.value.workflowInstanceId || undefined,
+      categoryCode: 'INVOICE',
+      fileName: file.name,
+      contentType: file.type || 'application/octet-stream',
+      fileSize: file.size,
+      sha256,
+      operatorId: currentUserId || document.value.applicantId,
+    })
+    const upload = requested?.data
+    if (!upload?.fileId || !upload?.uploadUrl) throw new Error('上传地址响应不完整')
+    await uploadWorkflowContent(sameOriginSignedUrl(upload.uploadUrl), file)
+    await confirmWorkflowUpload(upload.fileId, { operatorId: currentUserId || document.value.applicantId, sha256 })
+    selectedFiles.value = []
+    await loadAttachments()
+    showMessage('发票影像已上传并确认')
+  } catch (error) { showMessage(apiMessage(error, error?.message || '附件上传失败'), 'error') } finally { uploading.value = false }
+}
+
+async function removeAttachment(item) {
+  if (!window.confirm(`确认删除附件“${item.originalName}”吗？`)) return
+  try {
+    await deleteWorkflowAttachment(item.relationId, currentUserId || document.value.applicantId)
+    await loadAttachments()
+    showMessage('附件已删除')
+  } catch (error) { showMessage(apiMessage(error, '附件删除失败'), 'error') }
+}
+
+function downloadAttachment(item) {
+  if (!item.downloadUrl) return showMessage('当前附件没有可用的预览地址，请刷新附件列表', 'warning')
+  window.open(sameOriginSignedUrl(item.downloadUrl), '_blank', 'noopener,noreferrer')
 }
 
 function openEdit() {
-  editDialog.form = {
-    operatorId: currentUserId || document.value.applicantId,
-    departmentCode: document.value.departmentCode,
-    amount: Number(document.value.amount),
-    currency: document.value.currency || 'CNY',
-    description: document.value.description,
-    version: document.value.version,
-  }
+  editDialog.form = { operatorId: currentUserId || document.value.applicantId, departmentCode: document.value.departmentCode, amount: Number(document.value.amount), currency: document.value.currency || 'CNY', description: document.value.description, version: document.value.version }
   editDialog.visible = true
 }
 
 async function saveEdit() {
   const form = editDialog.form
-  if (!form.operatorId || !form.departmentCode || !form.description || Number(form.amount) <= 0) {
-    showMessage('请完整填写编辑信息', 'warning')
-    return
-  }
+  if (!form.operatorId || !form.departmentCode || !form.description || Number(form.amount) <= 0) return showMessage('请完整填写编辑信息', 'warning')
   editDialog.loading = true
-  try {
-    const response = await updateExpense(document.value.id, { ...form, amount: Number(form.amount) })
-    document.value = response?.data || document.value
-    editDialog.visible = false
-    showMessage('报销草稿已更新')
-  } catch (error) {
-    showMessage(error?.response?.data?.message || '报销单更新失败', 'error')
-  } finally {
-    editDialog.loading = false
-  }
+  try { const response = await updateExpense(document.value.id, { ...form, amount: Number(form.amount) }); document.value = response?.data || document.value; editDialog.visible = false; showMessage(isReturned.value ? '退回报销单已修改' : '报销草稿已更新') }
+  catch (error) { showMessage(apiMessage(error, '报销单更新失败'), 'error') } finally { editDialog.loading = false }
 }
 
 function openSubmit() {
+  if (!hasQualifiedInvoice.value) return showMessage('请先上传至少一份合格发票影像', 'warning')
   submitDialog.operatorId = currentUserId || document.value.applicantId
   submitDialog.definitionKey = 'expense-reimbursement'
   submitDialog.comment = ''
@@ -330,161 +296,60 @@ function openSubmit() {
 }
 
 async function submitDocument() {
-  if (!submitDialog.operatorId) {
-    showMessage('操作人不能为空', 'warning')
-    return
-  }
+  if (!submitDialog.operatorId) return showMessage('操作人不能为空', 'warning')
+  if (!hasQualifiedInvoice.value) { submitDialog.visible = false; return showMessage('发票附件状态已变化，请重新上传或刷新', 'warning') }
   submitDialog.loading = true
   try {
-    const response = await submitExpense(document.value.id, {
-      operatorId: submitDialog.operatorId,
-      definitionKey: submitDialog.definitionKey || undefined,
-      comment: submitDialog.comment || undefined,
-    })
+    const response = await submitExpense(document.value.id, { operatorId: submitDialog.operatorId, definitionKey: submitDialog.definitionKey || undefined, comment: submitDialog.comment || undefined })
     document.value = response?.data || document.value
     submitDialog.visible = false
-    showMessage('报销单已提交审批')
+    showMessage(isReturned.value ? '报销单已重新提交审批' : '报销单已提交审批')
     await loadApprovalDetail()
-  } catch (error) {
-    showMessage(error?.response?.data?.message || '提交审批失败', 'error')
-  } finally {
-    submitDialog.loading = false
-  }
+  } catch (error) { showMessage(apiMessage(error, '提交审批失败'), 'error') } finally { submitDialog.loading = false }
 }
 
-function openCancel() {
-  cancelDialog.operatorId = currentUserId || document.value.applicantId
-  cancelDialog.reason = ''
-  cancelDialog.visible = true
-}
-
+function openCancel() { cancelDialog.operatorId = currentUserId || document.value.applicantId; cancelDialog.reason = ''; cancelDialog.visible = true }
 async function cancelDocument() {
-  if (!cancelDialog.operatorId) {
-    showMessage('操作人不能为空', 'warning')
-    return
-  }
+  if (!cancelDialog.operatorId) return showMessage('操作人不能为空', 'warning')
   cancelDialog.loading = true
-  try {
-    const response = await cancelExpense(document.value.id, {
-      operatorId: cancelDialog.operatorId,
-      reason: cancelDialog.reason || undefined,
-    })
-    document.value = response?.data || document.value
-    cancelDialog.visible = false
-    showMessage('报销单已取消')
-  } catch (error) {
-    showMessage(error?.response?.data?.message || '取消报销单失败', 'error')
-  } finally {
-    cancelDialog.loading = false
-  }
+  try { const response = await cancelExpense(document.value.id, { operatorId: cancelDialog.operatorId, reason: cancelDialog.reason || undefined }); document.value = response?.data || document.value; cancelDialog.visible = false; showMessage('报销单取消请求已提交') }
+  catch (error) { showMessage(apiMessage(error, '取消报销单失败'), 'error') } finally { cancelDialog.loading = false }
 }
 
 async function loadApprovalDetail() {
   if (!document.value?.id) return
   approvalLoading.value = true
-  try {
-    const response = await getExpenseApprovalDetail(document.value.id)
-    approvalDetail.value = response?.data || null
-  } catch (error) {
-    showMessage(error?.response?.data?.message || '审批详情加载失败', 'error')
-  } finally {
-    approvalLoading.value = false
-  }
+  try { const response = await getExpenseApprovalDetail(document.value.id); approvalDetail.value = response?.data || null; if (Array.isArray(approvalDetail.value?.attachments)) attachments.value = approvalDetail.value.attachments }
+  catch (error) { showMessage(apiMessage(error, '审批详情加载失败'), 'error') } finally { approvalLoading.value = false }
 }
 
-function resetCreateForm() {
-  Object.assign(createForm, {
-    tenantId: 'default',
-    applicantId: currentUserId,
-    departmentCode: '',
-    amount: null,
-    currency: 'CNY',
-    description: '',
-  })
-  createFormRef.value?.resetValidation()
-}
-
-function syncQuery() {
-  if (!document.value?.id) return
-  router.replace({ path: '/expenses', query: { expenseId: document.value.id } })
-}
-
-function statusText(value) {
-  const map = {
-    DRAFT: '草稿', SUBMITTED: '审批中', APPROVING: '审批中', APPROVED: '已审批',
-    COMPLETED: '已完成', REJECTED: '已驳回', CANCELLED: '已取消', RETURNED: '已退回',
-  }
-  return map[(value || '').toUpperCase()] || value || '-'
-}
-
-function statusColor(value) {
-  const status = (value || '').toUpperCase()
-  if (['APPROVED', 'COMPLETED'].includes(status)) return 'success'
-  if (['REJECTED', 'CANCELLED'].includes(status)) return 'error'
-  if (['SUBMITTED', 'APPROVING'].includes(status)) return 'primary'
-  if (status === 'RETURNED') return 'warning'
-  return 'default'
-}
-
-function formatMoney(amount, currency) {
-  const value = Number(amount || 0)
-  try {
-    return new Intl.NumberFormat('zh-CN', { style: 'currency', currency: currency || 'CNY' }).format(value)
-  } catch (error) {
-    return `${currency || 'CNY'} ${value.toFixed(2)}`
-  }
-}
-
-function formatTime(value) {
-  if (!value) return '-'
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('zh-CN', { hour12: false })
-}
-
-function prettyJson(value) {
-  if (value == null) return '暂无数据'
-  try { return JSON.stringify(value, null, 2) } catch (error) { return String(value) }
-}
-
-function showMessage(text, color = 'success') {
-  snackbar.text = text
-  snackbar.color = color
-  snackbar.show = true
-}
+function resetCreateForm() { Object.assign(createForm, { tenantId: 'default', applicantId: currentUserId, departmentCode: '', amount: null, currency: 'CNY', description: '' }) }
+function syncQuery() { if (document.value?.id) router.replace({ path: route.path, query: { ...route.query, expenseId: document.value.id } }) }
+function isQualifiedInvoice(item) { return String(item?.categoryCode || '').toUpperCase() === 'INVOICE' && String(item?.uploadStatus || '').toUpperCase() === 'UPLOADED' && String(item?.scanStatus || '').toUpperCase() === 'CLEAN' }
+function attachmentStatusColor(item) { return isQualifiedInvoice(item) ? 'success' : String(item?.uploadStatus || '').toUpperCase() === 'PENDING' ? 'warning' : 'default' }
+function attachmentStatusText(item) { if (isQualifiedInvoice(item)) return '已确认、安全'; return `${item.uploadStatus || '未知'} / ${item.scanStatus || '未扫描'}` }
+function statusText(value) { return ({ DRAFT: '草稿', APPROVING: '审批中', RETURNED: '已退回', APPROVED: '已批准', REJECTED: '已驳回', CANCELLED: '已取消' }[String(value || '').toUpperCase()] || value || '-') }
+function statusColor(value) { const v = String(value || '').toUpperCase(); if (v === 'APPROVED') return 'success'; if (['REJECTED', 'CANCELLED'].includes(v)) return 'error'; if (v === 'RETURNED') return 'warning'; if (v === 'APPROVING') return 'primary'; return 'default' }
+function formatMoney(value, currency = 'CNY') { return new Intl.NumberFormat('zh-CN', { style: 'currency', currency: currency || 'CNY' }).format(Number(value || 0)) }
+function formatTime(value) { if (!value) return '-'; const date = new Date(value); return Number.isNaN(date.getTime()) ? value : date.toLocaleString('zh-CN', { hour12: false }) }
+function formatFileSize(bytes) { const value = Number(bytes || 0); if (value < 1024) return `${value} B`; if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`; return `${(value / 1024 / 1024).toFixed(1)} MB` }
+function prettyJson(value) { return JSON.stringify(value ?? {}, null, 2) }
+function showMessage(text, color = 'success') { snackbar.text = text; snackbar.color = color; snackbar.show = true }
+function apiMessage(error, fallback) { return error?.response?.data?.message || error?.response?.data?.msg || fallback }
+function sameOriginSignedUrl(value) { try { const url = new URL(value, window.location.origin); return `${url.pathname}${url.search}${url.hash}` } catch { return value } }
+async function digestFile(file) { const bytes = await file.arrayBuffer(); const hash = await crypto.subtle.digest('SHA-256', bytes); return Array.from(new Uint8Array(hash)).map(value => value.toString(16).padStart(2, '0')).join('') }
 </script>
 
 <style scoped>
-.expense-page { min-height: 100vh; padding: 30px; color: #233632; background: #f5f7f6; }
-.hero { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 22px; padding: 30px 34px; border-radius: 24px; color: #fff; background: linear-gradient(135deg, #6f5320, #b3832e); }
-.hero span { font-size: 11px; font-weight: 800; letter-spacing: .16em; opacity: .72; }
-.hero h1 { margin: 8px 0 0; font-size: 36px; }
-.hero p { margin: 12px 0 0; opacity: .78; }
-.hero-actions { display: flex; gap: 10px; }
-.workspace-grid { display: grid; grid-template-columns: minmax(360px, .9fr) minmax(460px, 1.1fr); gap: 20px; align-items: start; }
-.detail-column { display: grid; gap: 16px; }
-.create-card, .lookup-card, .detail-card, .empty-card, .approval-card { border: 1px solid #e0e7e4; border-radius: 18px; background: #fff; }
-.lookup-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; align-items: center; }
-.detail-heading, .approval-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; padding: 22px 24px 8px; }
-.detail-heading span, .approval-heading span { color: #8a7a5d; font-size: 11px; font-weight: 800; letter-spacing: .12em; }
-.detail-heading h2, .approval-heading h2 { margin: 5px 0 0; font-size: 22px; }
-.metric-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
-.metric-grid article { padding: 14px; border-radius: 13px; background: #f7f4ec; }
-.metric-grid span, .metric-grid strong { display: block; }
-.metric-grid span { color: #8d8069; font-size: 11px; }
-.metric-grid strong { margin-top: 6px; font-size: 15px; }
-.detail-list { margin-top: 14px; border-radius: 12px; background: #fafbfa; }
-.detail-actions { flex-wrap: wrap; padding: 8px 20px 20px; }
-.empty-card { display: grid; min-height: 310px; place-items: center; align-content: center; gap: 10px; color: #87948f; }
-.empty-card strong { color: #425a54; }
-.approval-card { margin-top: 20px; padding: 0 22px 22px; }
-.json-panel { height: 100%; padding: 16px; border: 1px solid #e6ece9; border-radius: 14px; background: #f8faf9; }
-.json-panel pre { max-height: 320px; overflow: auto; margin: 12px 0 0; white-space: pre-wrap; word-break: break-word; font-size: 12px; }
-@media (max-width: 1050px) { .workspace-grid { grid-template-columns: 1fr; } }
-@media (max-width: 720px) {
-  .expense-page { padding: 16px; }
-  .hero { align-items: flex-start; flex-direction: column; padding: 24px; }
-  .hero h1 { font-size: 28px; }
-  .hero-actions { width: 100%; flex-wrap: wrap; }
-  .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-}
+.expense-page { min-height: 100vh; padding: 30px; color: #20322f; background: #f4f7f6; }
+.hero { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 22px; padding: 30px 34px; border-radius: 24px; color: white; background: linear-gradient(135deg, #81531f, #c18a3d); }
+.hero span, .section-heading span, .detail-heading span { font-size: 11px; font-weight: 800; letter-spacing: .14em; opacity: .72; }
+.hero h1, .section-heading h2, .detail-heading h2 { margin: 7px 0 0; }.hero h1 { font-size: 36px; }.hero p { margin: 12px 0 0; opacity: .8; }.hero-actions, .row-actions { display: flex; gap: 8px; }
+.workspace-grid { display: grid; grid-template-columns: minmax(340px, .85fr) minmax(420px, 1.15fr); gap: 20px; }.detail-column { display: grid; align-content: start; gap: 16px; }
+.panel-card, .lookup-card, .attachment-card, .approval-card, .empty-card { border: 1px solid #dfe8e5; border-radius: 18px; background: white; }.lookup-row { display: flex; align-items: center; gap: 10px; }
+.detail-heading, .section-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; padding: 22px 24px 8px; }.detail-heading h2 { font-size: 20px; }.section-heading p { margin: 8px 0 0; color: #758680; }
+.metric-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }.metric-grid article { padding: 14px; border-radius: 12px; background: #f4f7f6; }.metric-grid span, .file-cell small { display: block; color: #788a84; font-size: 12px; }.metric-grid strong { display: block; margin-top: 6px; }.detail-actions { flex-wrap: wrap; padding: 8px 20px 18px; }.action-alert { margin: 0 20px 20px; }
+.empty-card { display: grid; justify-items: center; gap: 8px; padding: 60px 20px; color: #87958f; }.empty-card strong { color: #405852; }.attachment-card, .approval-card { margin-top: 20px; padding-bottom: 8px; }.upload-row { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 12px; margin-bottom: 18px; }
+.file-cell { display: flex; align-items: center; gap: 10px; }.file-cell strong { display: block; }.table-empty { padding: 32px; color: #85948f; }.json-panel { min-height: 180px; padding: 16px; border-radius: 12px; background: #f4f7f6; }.json-panel pre { overflow: auto; max-height: 300px; white-space: pre-wrap; font-size: 12px; }
+@media (max-width: 960px) { .expense-page { padding: 16px; }.hero { align-items: flex-start; flex-direction: column; padding: 24px; }.hero h1 { font-size: 28px; }.workspace-grid { grid-template-columns: 1fr; }.metric-grid { grid-template-columns: repeat(2, 1fr); }.upload-row { grid-template-columns: 1fr; } }
 </style>

--- a/src/views/login/shared/SharedOperationsView.vue
+++ b/src/views/login/shared/SharedOperationsView.vue
@@ -1,616 +1,237 @@
 <template>
-  <v-container class="shared-operations" fluid>
-    <v-breadcrumbs :items="breadcrumbs" class="mb-6" divider="mdi-chevron-right" />
+  <main class="shared-page">
+    <section class="hero">
+      <div>
+        <span>SHARED OPERATIONS</span>
+        <h1>共享运营任务池</h1>
+        <p>真实连接共享服务 API，统一管理任务创建、认领、执行、验收、评论和 SLA。</p>
+      </div>
+      <div class="hero-actions">
+        <v-btn variant="tonal" prepend-icon="mdi-refresh" :loading="loading" @click="refreshAll">刷新</v-btn>
+        <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreate">创建任务</v-btn>
+      </div>
+    </section>
 
-    <v-row class="mb-6" align="stretch" no-gutters>
-      <v-col cols="12" md="4" class="pr-md-4 mb-6 mb-md-0">
-        <v-card class="info-card" elevation="2">
-          <v-card-title class="d-flex align-center">
-            <v-avatar color="primary" size="40" class="mr-3">
-              <v-icon icon="mdi-account-group-outline" size="26" />
-            </v-avatar>
-            <div>
-              <div class="text-h6 font-weight-bold">共享运营管理</div>
-              <div class="text-body-2 text-medium-emphasis">统一管理共享服务运营任务</div>
-            </div>
-          </v-card-title>
-          <v-divider class="my-3" />
-          <v-card-text>
-            <div class="text-body-2 text-medium-emphasis mb-4">
-              通过标准化任务池，实现跨团队协作、进度追踪与质量管控，支撑共享服务体系的高效运营。
-            </div>
-            <v-chip-group column class="chip-group" selected-class="bg-primary">
-              <v-chip color="primary" class="text-body-2" variant="tonal" prepend-icon="mdi-format-list-checks">
-                共享任务
-              </v-chip>
-              <v-chip color="primary" class="text-body-2" variant="text" prepend-icon="mdi-account-arrow-left">
-                拉式认领
-              </v-chip>
-              <v-chip color="primary" class="text-body-2" variant="text" prepend-icon="mdi-shield-check">
-                风险防控
-              </v-chip>
-              <v-chip color="primary" class="text-body-2" variant="text" prepend-icon="mdi-chart-areaspline">
-                运营看板
-              </v-chip>
-            </v-chip-group>
-            <v-alert type="info" variant="tonal" density="comfortable" class="mt-4">
-              共享任务涵盖了任务创建、认领、执行、验收与复盘的全生命周期。
-            </v-alert>
-          </v-card-text>
-        </v-card>
-      </v-col>
-      <v-col cols="12" md="8">
-        <v-card elevation="2" class="task-card">
-          <v-card-title class="d-flex align-center justify-space-between">
-            <div class="d-flex align-center">
-              <v-icon icon="mdi-clipboard-list-outline" color="primary" size="28" class="mr-3" />
-              <div>
-                <div class="text-h6 font-weight-bold">共享任务</div>
-                <div class="text-caption text-medium-emphasis">请完善任务信息，确保入池标准与风险可控</div>
-              </div>
-            </div>
-            <div>
-              <v-btn class="mr-2" color="primary" variant="tonal" @click="resetForm">重置</v-btn>
-              <v-btn color="primary" @click="simulateSubmit">提交</v-btn>
-            </div>
-          </v-card-title>
-          <v-divider />
-          <v-card-text>
-            <v-form ref="taskForm">
-              <section-title title="基础信息" />
-              <v-row>
-                <v-col cols="12" md="6">
-                  <v-text-field
-                    v-model="form.title"
-                    label="title｜标题"
-                    :rules="titleRules"
-                    maxlength="120"
-                    counter
-                    placeholder="请用“模块-场景-关键词”命名"
-                    required
-                  />
-                </v-col>
-                <v-col cols="12" md="6">
-                  <v-select
-                    v-model="form.priority"
-                    :items="priorityOptions"
-                    label="priority｜优先级"
-                    item-title="label"
-                    item-value="value"
-                    required
-                    :chips="false"
-                    class="priority-select"
-                  >
-                    <template #selection="{ item }">
-                      <v-chip :color="priorityColor(item.value)" size="small" variant="flat">{{ item.value }}</v-chip>
-                    </template>
-                    <template #item="{ props, item }">
-                      <v-list-item v-bind="props">
-                        <template #prepend>
-                          <v-avatar :color="priorityColor(item.value)" size="18" />
-                        </template>
-                        <template #title>
-                          {{ item.value }}
-                        </template>
-                      </v-list-item>
-                    </template>
-                  </v-select>
-                </v-col>
-                <v-col cols="12">
-                  <v-textarea
-                    v-model="form.description"
-                    label="description｜描述"
-                    rows="3"
-                    counter
-                    :rules="descriptionRules"
-                    placeholder="请描述复现场景 / 期望 / 验收方式"
-                    auto-grow
-                    required
-                  />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-text-field v-model="form.requester" label="requester｜提交人" readonly variant="outlined" />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-autocomplete v-model="form.assignee" :items="assigneeOptions" label="assignee｜负责人" clearable chips hide-no-data />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-select v-model="form.status" :items="statusOptions" label="status｜状态" required />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-text-field
-                    v-model="form.dueDate"
-                    label="dueDate｜截止日期"
-                    type="date"
-                    :min="minDueDate"
-                    clearable
-                  />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-combobox
-                    v-model="form.labels"
-                    label="labels｜标签"
-                    multiple
-                    chips
-                    clearable
-                    hint="最多 3 个标签"
-                    persistent-hint
-                  />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-select v-model="form.module" :items="moduleOptions" label="module｜模块" required />
-                </v-col>
-                <v-col cols="12">
-                  <v-combobox
-                    v-model="form.acceptanceCriteria"
-                    label="acceptanceCriteria｜验收标准"
-                    multiple
-                    chips
-                    hint="至少添加 1 条可验证的验收标准"
-                    persistent-hint
-                  />
-                </v-col>
-              </v-row>
+    <section class="summary-grid">
+      <article><span>任务总数</span><strong>{{ summary.totalCreated || 0 }}</strong><small>当前统计周期创建量</small></article>
+      <article><span>已完成</span><strong>{{ summary.completed || 0 }}</strong><small>完成率 {{ completionRate }}%</small></article>
+      <article><span>已逾期</span><strong>{{ summary.overdue || 0 }}</strong><small>需要优先处理</small></article>
+      <article><span>平均任务年龄</span><strong>{{ summary.avgAgeDays || 0 }} 天</strong><small>从创建至当前</small></article>
+    </section>
 
-              <section-title title="影响与来源" />
-              <v-row>
-                <v-col cols="12" md="4">
-                  <v-select v-model="form.impactScope" :items="impactScopeOptions" label="impactScope｜影响范围" clearable />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-select v-model="form.ticketSource" :items="ticketSourceOptions" label="ticketSource｜来源" clearable />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-select v-model="form.taskType" :items="taskTypeOptions" label="taskType｜类型" required />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-text-field v-model.number="form.estimate" label="estimate｜预估 (h / pts)" type="number" min="0" suffix="h" />
-                </v-col>
-                <v-col cols="12" md="8">
-                  <v-combobox v-model="form.dependencies" label="dependencies｜依赖项" multiple chips clearable />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-select v-model="form.slaClass" :items="slaOptions" label="slaClass｜SLA等级" />
-                </v-col>
-              </v-row>
+    <v-card class="filter-card" elevation="0">
+      <v-card-text>
+        <v-row dense>
+          <v-col cols="12" md="3"><v-text-field v-model.trim="filters.search" label="搜索标题或描述" prepend-inner-icon="mdi-magnify" variant="outlined" density="comfortable" hide-details clearable @keydown.enter="applyFilters" /></v-col>
+          <v-col cols="12" md="2"><v-select v-model="filters.status" label="状态" :items="statusOptions" variant="outlined" density="comfortable" hide-details clearable /></v-col>
+          <v-col cols="12" md="2"><v-select v-model="filters.priority" label="优先级" :items="priorityOptions" variant="outlined" density="comfortable" hide-details clearable /></v-col>
+          <v-col cols="12" md="3"><v-text-field v-model.trim="filters.module" label="模块" variant="outlined" density="comfortable" hide-details clearable /></v-col>
+          <v-col cols="12" md="2"><v-btn color="primary" block height="44" @click="applyFilters">查询</v-btn></v-col>
+        </v-row>
+      </v-card-text>
+    </v-card>
 
-              <section-title title="子任务与执行" />
-              <v-row class="align-center mb-2">
-                <v-col cols="12" md="8">
-                  <div class="text-body-2 text-medium-emphasis">
-                    请拆解子任务并更新完成状态，进度条将随完成率变化。
-                  </div>
-                </v-col>
-                <v-col cols="12" md="4" class="text-md-right">
-                  <v-btn color="primary" variant="text" prepend-icon="mdi-plus" @click="addSubtask">新增子任务</v-btn>
-                </v-col>
-              </v-row>
-              <v-row v-for="(subtask, index) in form.subtasks" :key="index" class="subtask-row" align="center">
-                <v-col cols="12" md="8">
-                  <v-text-field v-model="subtask.title" :label="`子任务 ${index + 1}`" required />
-                </v-col>
-                <v-col cols="6" md="2">
-                  <v-switch v-model="subtask.done" inset color="success" :label="subtask.done ? '已完成' : '未完成'" />
-                </v-col>
-                <v-col cols="6" md="2" class="text-right">
-                  <v-btn icon variant="text" color="default" @click="removeSubtask(index)" :disabled="form.subtasks.length === 1">
-                    <v-icon icon="mdi-delete-outline" />
-                  </v-btn>
-                </v-col>
-              </v-row>
-              <v-progress-linear :model-value="subtaskProgress" color="primary" class="mb-6" rounded height="8" />
+    <v-card class="table-card" elevation="0">
+      <div class="table-heading">
+        <div><span>TASK POOL</span><strong>共享任务</strong></div>
+        <small>共 {{ total }} 条 · 第 {{ page }} / {{ pageCount }} 页</small>
+      </div>
+      <v-data-table :headers="headers" :items="tasks" :loading="loading" item-value="id" :items-per-page="pageSize" hide-default-footer @click:row="openRow">
+        <template #item.title="{ item }"><button type="button" class="task-link" @click.stop="openDetail(item)"><strong>{{ item.title }}</strong><small>{{ item.id }}</small></button></template>
+        <template #item.priority="{ item }"><v-chip size="small" :color="priorityColor(item.priority)" variant="tonal">{{ item.priority || '-' }}</v-chip></template>
+        <template #item.status="{ item }"><v-chip size="small" :color="statusColor(item.status)" variant="tonal">{{ item.status || '-' }}</v-chip></template>
+        <template #item.assignee="{ item }">{{ item.assignee?.name || item.assignee?.id || '未认领' }}</template>
+        <template #item.dueDate="{ item }">{{ item.dueDate || '-' }}</template>
+        <template #item.actions="{ item }"><div class="row-actions">
+          <v-btn v-if="!item.assignee" size="small" variant="tonal" color="primary" @click.stop="claimTask(item)">认领</v-btn>
+          <v-btn size="small" variant="text" @click.stop="openTransition(item)">流转</v-btn>
+          <v-btn size="small" variant="text" @click.stop="openEdit(item)">编辑</v-btn>
+          <v-btn size="small" variant="text" color="error" @click.stop="removeTask(item)">删除</v-btn>
+        </div></template>
+        <template #no-data><div class="empty-state"><v-icon size="44">mdi-clipboard-text-outline</v-icon><strong>暂无共享任务</strong><span>调整筛选条件或创建一个新任务。</span></div></template>
+      </v-data-table>
+      <div class="pagination-bar"><v-pagination v-model="page" :length="pageCount" :total-visible="7" @update:model-value="loadTasks" /></div>
+    </v-card>
 
-              <section-title title="时间追踪" />
-              <v-row>
-                <v-col cols="12" md="3">
-                  <v-text-field v-model="form.firstResponseAt" label="firstResponseAt｜首次响应" readonly />
-                </v-col>
-                <v-col cols="12" md="3">
-                  <v-text-field v-model="form.createdAt" label="createdAt｜创建时间" readonly />
-                </v-col>
-                <v-col cols="12" md="3">
-                  <v-text-field v-model="form.completedAt" label="completedAt｜完成时间" readonly />
-                </v-col>
-                <v-col cols="12" md="3">
-                  <v-text-field :model-value="ageDays" label="ageDays｜任务年龄 (天)" readonly />
-                </v-col>
-              </v-row>
+    <v-dialog v-model="formDialog.visible" max-width="820" persistent>
+      <v-card>
+        <v-card-title>{{ formDialog.mode === 'create' ? '创建共享任务' : '编辑共享任务' }}</v-card-title>
+        <v-card-text>
+          <v-form ref="taskFormRef">
+            <v-row dense>
+              <v-col cols="12" md="8"><v-text-field v-model.trim="formDialog.form.title" label="标题" maxlength="120" counter variant="outlined" :rules="requiredRules" /></v-col>
+              <v-col cols="12" md="4"><v-select v-model="formDialog.form.priority" label="优先级" :items="priorityOptions" variant="outlined" /></v-col>
+              <v-col cols="12"><v-textarea v-model.trim="formDialog.form.description" label="描述" rows="4" auto-grow counter variant="outlined" hint="至少 20 个字符" persistent-hint :rules="descriptionRules" /></v-col>
+              <v-col cols="12" md="4"><v-select v-model="formDialog.form.taskType" label="任务类型" :items="taskTypeOptions" variant="outlined" /></v-col>
+              <v-col cols="12" md="4"><v-text-field v-model.trim="formDialog.form.module" label="模块" variant="outlined" :rules="requiredRules" /></v-col>
+              <v-col cols="12" md="4"><v-select v-model="formDialog.form.riskLevel" label="风险等级" :items="riskOptions" variant="outlined" /></v-col>
+              <v-col cols="12" md="6"><v-text-field v-model="formDialog.form.dueDate" type="date" label="截止日期" variant="outlined" /></v-col>
+              <v-col cols="12" md="6"><v-combobox v-model="formDialog.form.labels" label="标签" multiple chips clearable variant="outlined" /></v-col>
+              <v-col cols="12"><v-textarea v-model="formDialog.form.acceptanceText" label="验收标准" rows="3" variant="outlined" hint="每行一条，至少一条" persistent-hint :rules="requiredRules" /></v-col>
+            </v-row>
+          </v-form>
+        </v-card-text>
+        <v-card-actions><v-spacer /><v-btn variant="text" @click="formDialog.visible = false">取消</v-btn><v-btn color="primary" :loading="formDialog.loading" @click="saveTask">保存</v-btn></v-card-actions>
+      </v-card>
+    </v-dialog>
 
-              <section-title title="沟通与关联" />
-              <v-row>
-                <v-col cols="12" md="6">
-                  <v-file-input v-model="form.attachments" label="attachments｜附件" multiple prepend-icon="mdi-paperclip" />
-                </v-col>
-                <v-col cols="12" md="6">
-                  <v-combobox v-model="form.relatedLinks" label="relatedLinks｜关联链接" multiple chips clearable />
-                </v-col>
-                <v-col cols="12" md="6">
-                  <v-text-field v-model="form.milestone" label="milestone｜里程碑" />
-                </v-col>
-                <v-col cols="12" md="6">
-                  <v-select v-model="form.quarter" :items="quarterOptions" label="quarter｜归属季度" clearable />
-                </v-col>
-              </v-row>
+    <v-dialog v-model="transitionDialog.visible" max-width="560" persistent>
+      <v-card><v-card-title>任务状态流转</v-card-title><v-card-text>
+        <v-alert type="info" variant="tonal" class="mb-4">{{ transitionDialog.task?.title }} · 当前状态 {{ transitionDialog.task?.status }}</v-alert>
+        <v-select v-model="transitionDialog.targetStatus" label="目标状态" :items="statusOptions" variant="outlined" />
+        <v-textarea v-model.trim="transitionDialog.note" label="流转备注" variant="outlined" rows="4" :rules="requiredRules" />
+      </v-card-text><v-card-actions><v-spacer /><v-btn variant="text" @click="transitionDialog.visible = false">取消</v-btn><v-btn color="primary" :loading="transitionDialog.loading" @click="submitTransition">确认流转</v-btn></v-card-actions></v-card>
+    </v-dialog>
 
-              <section-title title="质量与风险" />
-              <v-row>
-                <v-col cols="12">
-                  <v-combobox
-                    v-model="form.dorCheck"
-                    label="dorCheck｜入池标准"
-                    multiple
-                    chips
-                    hint="示例：场景清晰 / 可测 / 口径明确"
-                    persistent-hint
-                  />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-select v-model="form.riskLevel" :items="riskOptions" label="riskLevel｜风险等级" />
-                </v-col>
-                <v-col cols="12" md="8">
-                  <v-textarea v-model="form.rollbackPlan" label="rollbackPlan｜回滚方案" auto-grow rows="2" />
-                </v-col>
-                <v-col cols="12" md="6">
-                  <v-file-input v-model="form.testEvidence" label="testEvidence｜测试证据" multiple prepend-icon="mdi-clipboard-check" />
-                </v-col>
-                <v-col cols="12" md="6">
-                  <v-combobox v-model="form.testEvidenceLinks" label="testEvidence｜测试链接" multiple chips />
-                </v-col>
-              </v-row>
+    <v-dialog v-model="detailDialog.visible" max-width="900" scrollable>
+      <v-card><v-card-title class="detail-title"><div><small>{{ detailDialog.task?.id }}</small><strong>{{ detailDialog.task?.title }}</strong></div><v-btn icon="mdi-close" variant="text" @click="detailDialog.visible = false" /></v-card-title>
+        <v-card-text v-if="detailDialog.task">
+          <div class="detail-metrics">
+            <article><span>状态</span><strong>{{ detailDialog.task.status }}</strong></article>
+            <article><span>优先级</span><strong>{{ detailDialog.task.priority }}</strong></article>
+            <article><span>负责人</span><strong>{{ detailDialog.task.assignee?.name || '未认领' }}</strong></article>
+            <article><span>SLA</span><strong>{{ detailDialog.sla?.targetHours ?? '-' }} h</strong></article>
+          </div>
+          <v-alert type="info" variant="tonal" class="my-4">{{ detailDialog.task.description }}</v-alert>
+          <v-list lines="two" density="comfortable">
+            <v-list-item title="模块" :subtitle="detailDialog.task.module || '-'" />
+            <v-list-item title="验收标准" :subtitle="(detailDialog.task.acceptanceCriteria || []).join('；') || '-'" />
+            <v-list-item title="创建人" :subtitle="detailDialog.task.requester?.name || detailDialog.task.requester?.id || '-'" />
+            <v-list-item title="创建时间" :subtitle="formatTime(detailDialog.task.createdAt)" />
+          </v-list>
+          <v-divider class="my-4" />
+          <div class="comment-heading"><strong>评论记录</strong><v-chip size="small" variant="tonal">{{ detailDialog.comments.length }} 条</v-chip></div>
+          <div v-if="detailDialog.comments.length" class="comment-list"><article v-for="comment in detailDialog.comments" :key="comment.id"><header><strong>{{ comment.author?.name || comment.author?.id || '用户' }}</strong><small>{{ formatTime(comment.createdAt) }}</small></header><p>{{ comment.body }}</p></article></div>
+          <div v-else class="comment-empty">暂无评论</div>
+          <div class="comment-form"><v-textarea v-model.trim="detailDialog.newComment" label="添加评论" rows="2" auto-grow variant="outlined" hide-details /><v-btn color="primary" :loading="detailDialog.commentLoading" @click="submitComment">发送</v-btn></div>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
 
-              <section-title title="执行与发布" />
-              <v-row>
-                <v-col cols="12" md="4">
-                  <v-select v-model="form.ownerTeam" :items="ownerTeamOptions" label="ownerTeam｜负责人团队" clearable />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-combobox v-model="form.coOwners" label="coOwners｜协作者" multiple chips clearable />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-select v-model="form.env" :items="envOptions" label="env｜环境" />
-                </v-col>
-                <v-col cols="12" md="6">
-                  <v-text-field v-model="form.releaseLink" label="releaseLink｜发布单" type="url" />
-                </v-col>
-                <v-col cols="12" md="6">
-                  <v-combobox v-model="form.prLinks" label="prLinks｜代码PR链接" multiple chips />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-chip color="success" class="mt-5" variant="tonal">CI 状态：{{ form.ciStatus }}</v-chip>
-                </v-col>
-              </v-row>
-
-              <section-title title="追踪与审计" />
-              <v-row>
-                <v-col cols="12" md="3">
-                  <v-text-field v-model="form.reopenCount" type="number" label="reopenCount｜退回次数" readonly />
-                </v-col>
-                <v-col cols="12" md="5">
-                  <v-text-field v-model="form.duplicateOf" label="duplicateOf｜重复任务指向" />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-select v-model="form.securityLevel" :items="securityOptions" label="securityLevel｜敏感级别" />
-                </v-col>
-                <v-col cols="12">
-                  <v-card variant="tonal" class="mt-2">
-                    <v-card-title class="text-subtitle-2">eventLog｜事件流水</v-card-title>
-                    <v-divider />
-                    <v-list density="comfortable">
-                      <v-list-item v-for="(event, idx) in form.eventLog" :key="idx">
-                        <v-list-item-title>{{ event.title }}</v-list-item-title>
-                        <v-list-item-subtitle>{{ event.time }} · {{ event.actor }}</v-list-item-subtitle>
-                      </v-list-item>
-                    </v-list>
-                  </v-card>
-                </v-col>
-              </v-row>
-
-              <section-title title="业务价值" />
-              <v-row>
-                <v-col cols="12" md="4">
-                  <v-text-field v-model="form.expectedValue" label="expectedValue｜预期价值" />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <v-text-field v-model="form.postmortem" label="postmortem｜复盘链接" type="url" />
-                </v-col>
-                <v-col cols="12" md="4">
-                  <div class="d-flex align-center">
-                    <span class="text-body-2 mr-4">csat｜验收满意度</span>
-                    <v-slider v-model="form.csat" min="1" max="5" step="1" thumb-label ticks show-ticks="always" />
-                  </div>
-                </v-col>
-              </v-row>
-            </v-form>
-          </v-card-text>
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-container>
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="2800">{{ snackbar.text }}</v-snackbar>
+  </main>
 </template>
 
 <script setup>
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
+import { addSharedTaskComment, createSharedTask, deleteSharedTask, getSharedOperationsSummary, getSharedTask, getSharedTaskSla, listSharedTaskComments, listSharedTasks, transitionSharedTask, updateSharedTask } from '@/api/sharedOperations'
+import { getCurrentUserId } from '@/utils/currentUser'
 
-const breadcrumbs = [
-  { title: '共享云', disabled: false, href: '#' },
-  { title: '共享运营管理', disabled: false, href: '#' },
-  { title: '共享任务', disabled: true },
-]
-
-const taskForm = ref(null)
-
-const form = reactive({
-  title: '',
-  description: '',
-  priority: 'P2',
-  requester: '当前用户',
-  assignee: null,
-  status: '待分诊',
-  dueDate: '',
-  labels: [],
-  module: '共享运营',
-  acceptanceCriteria: ['输入→处理→输出可验证'],
-  impactScope: null,
-  ticketSource: null,
-  taskType: '运营',
-  estimate: null,
-  subtasks: [
-    { title: '梳理需求背景', done: false },
-    { title: '制定执行方案', done: false },
-  ],
-  dependencies: [],
-  slaClass: 'SLA-P2',
-  firstResponseAt: '',
-  createdAt: new Date().toISOString().slice(0, 16).replace('T', ' '),
-  completedAt: '',
-  attachments: [],
-  relatedLinks: [],
-  milestone: '',
-  quarter: null,
-  dorCheck: ['场景清晰'],
-  riskLevel: '中',
-  rollbackPlan: '',
-  testEvidence: [],
-  testEvidenceLinks: [],
-  ownerTeam: null,
-  coOwners: [],
-  env: '测试',
-  releaseLink: '',
-  prLinks: [],
-  ciStatus: '进行中',
-  eventLog: [
-    { title: '任务创建', time: new Date().toLocaleString(), actor: '当前用户' },
-  ],
-  reopenCount: 0,
-  duplicateOf: '',
-  securityLevel: '内部',
-  expectedValue: '',
-  postmortem: '',
-  csat: 3,
-})
-
-const titleRules = [
-  v => !!v || '标题为必填项',
-  v => (v && v.length <= 120) || '标题长度需在 120 字以内',
-]
-
-const descriptionRules = [
-  v => !!v || '描述为必填项',
-  v => (v && v.length >= 20) || '描述需至少 20 字',
-]
-
-const priorityOptions = [
-  { label: '最高优先级', value: 'P0' },
-  { label: '高优先级', value: 'P1' },
-  { label: '默认优先级', value: 'P2' },
-  { label: '低优先级', value: 'P3' },
-]
-
+const currentUserId = getCurrentUserId() || 'current-user'
+const loading = ref(false)
+const tasks = ref([])
+const total = ref(0)
+const page = ref(1)
+const pageSize = ref(20)
+const taskFormRef = ref(null)
+const summary = reactive({ totalCreated: 0, completed: 0, overdue: 0, avgAgeDays: 0 })
+const filters = reactive({ search: '', status: null, priority: null, module: '' })
+const snackbar = reactive({ show: false, text: '', color: 'success' })
 const statusOptions = ['待分诊', '待办', '进行中', '待验收', '已完成', '搁置', '阻塞']
-const moduleOptions = ['共享运营', '共享客服', '共享财务', '共享法务']
-const impactScopeOptions = ['单用户', '≤1%', '1–5%', '>5%', '关键客户', '金额区间']
-const ticketSourceOptions = ['客户', '运营', '监控', '内部', '渠道名']
+const priorityOptions = ['P0', 'P1', 'P2', 'P3']
 const taskTypeOptions = ['缺陷', '需求', '运营', '支持', '数据', '自动化']
-const slaOptions = ['SLA-P0', 'SLA-P1', 'SLA-P2']
-const assigneeOptions = ['张敏', '王涛', '李静', '陈岚']
-const quarterOptions = ['FY25Q1', 'FY25Q2', 'FY25Q3', 'FY25Q4']
 const riskOptions = ['高', '中', '低']
-const ownerTeamOptions = ['共享运营组', '共享质检组', '共享客服组']
-const envOptions = ['生产', '预发', '测试']
-const securityOptions = ['公开', '内部', '涉密']
+const requiredRules = [value => Boolean(Array.isArray(value) ? value.length : String(value || '').trim()) || '此项不能为空']
+const descriptionRules = [value => String(value || '').trim().length >= 20 || '描述至少 20 个字符']
+const headers = [
+  { title: '任务', key: 'title', minWidth: 260 },
+  { title: '优先级', key: 'priority', width: 100 },
+  { title: '状态', key: 'status', width: 120 },
+  { title: '模块', key: 'module', width: 140 },
+  { title: '负责人', key: 'assignee', width: 140 },
+  { title: '截止日期', key: 'dueDate', width: 130 },
+  { title: '操作', key: 'actions', width: 260, sortable: false },
+]
+const formDialog = reactive({ visible: false, loading: false, mode: 'create', taskId: null, form: emptyForm() })
+const transitionDialog = reactive({ visible: false, loading: false, task: null, targetStatus: '进行中', note: '' })
+const detailDialog = reactive({ visible: false, task: null, sla: null, comments: [], newComment: '', commentLoading: false })
+const pageCount = computed(() => Math.max(1, Math.ceil(total.value / pageSize.value)))
+const completionRate = computed(() => summary.totalCreated ? Math.round((summary.completed / summary.totalCreated) * 100) : 0)
 
-const minDueDate = computed(() => new Date().toISOString().split('T')[0])
+onMounted(refreshAll)
 
-const ageDays = computed(() => {
-  const created = new Date(form.createdAt)
-  if (Number.isNaN(created.getTime())) return '-'
-  const now = new Date()
-  const diff = Math.floor((now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24))
-  return diff >= 0 ? diff : 0
-})
-
-const subtaskProgress = computed(() => {
-  const total = form.subtasks.length
-  if (!total) return 0
-  const done = form.subtasks.filter(item => item.done).length
-  return Math.round((done / total) * 100)
-})
-
-watch(() => form.priority, value => {
-  const mapping = {
-    P0: 'SLA-P0',
-    P1: 'SLA-P1',
-    P2: 'SLA-P2',
-    P3: 'SLA-P2',
-  }
-  form.slaClass = mapping[value] || 'SLA-P2'
-})
-
-watch(
-  () => form.labels,
-  labels => {
-    if (labels.length > 3) {
-      labels.splice(3)
+function emptyForm() { return { title: '', description: '', priority: 'P2', taskType: '运营', module: '共享运营', riskLevel: '中', dueDate: '', labels: [], acceptanceText: '输入、处理和输出均可验证' } }
+async function refreshAll() { await Promise.all([loadTasks(), loadSummary()]) }
+async function loadTasks() {
+  loading.value = true
+  try {
+    const response = await listSharedTasks({ status: filters.status || undefined, module: filters.module || undefined, priority: filters.priority || undefined, search: filters.search || undefined, page: page.value, pageSize: pageSize.value, sort: '-createdAt' })
+    tasks.value = Array.isArray(response?.data) ? response.data : []
+    total.value = Number(response?.pagination?.total || response?.pagination?.totalCount || tasks.value.length)
+  } catch (error) { tasks.value = []; total.value = 0; showMessage(apiMessage(error, '共享任务加载失败'), 'error') } finally { loading.value = false }
+}
+async function loadSummary() {
+  try { const response = await getSharedOperationsSummary(); Object.assign(summary, response?.data || {}) }
+  catch { Object.assign(summary, { totalCreated: 0, completed: 0, overdue: 0, avgAgeDays: 0 }) }
+}
+function applyFilters() { page.value = 1; loadTasks() }
+function openCreate() { formDialog.mode = 'create'; formDialog.taskId = null; formDialog.form = emptyForm(); formDialog.visible = true }
+function openEdit(task) { formDialog.mode = 'edit'; formDialog.taskId = task.id; formDialog.form = { title: task.title || '', description: task.description || '', priority: task.priority || 'P2', taskType: task.taskType || '运营', module: task.module || '共享运营', riskLevel: task.riskLevel || '中', dueDate: task.dueDate || '', labels: [...(task.labels || [])], acceptanceText: (task.acceptanceCriteria || []).join('\n') }; formDialog.visible = true }
+async function saveTask() {
+  const validation = await taskFormRef.value?.validate()
+  if (validation && !validation.valid) return
+  const form = formDialog.form
+  const acceptanceCriteria = String(form.acceptanceText || '').split('\n').map(value => value.trim()).filter(Boolean)
+  if (!acceptanceCriteria.length) return showMessage('至少填写一条验收标准', 'warning')
+  formDialog.loading = true
+  try {
+    if (formDialog.mode === 'create') {
+      await createSharedTask({ title: form.title, description: form.description, priority: form.priority, taskType: form.taskType, module: form.module, status: '待分诊', riskLevel: form.riskLevel, dueDate: form.dueDate || undefined, labels: form.labels || [], acceptanceCriteria, securityLevel: '内部' })
+      showMessage('共享任务已创建并写入任务池')
+    } else {
+      await updateSharedTask(formDialog.taskId, { title: form.title, description: form.description, priority: form.priority, dueDate: form.dueDate || null, labels: form.labels || [], acceptanceCriteria })
+      showMessage('共享任务已更新')
     }
-  },
-  { deep: true }
-)
-
-function priorityColor(priority) {
-  switch (priority) {
-    case 'P0':
-      return 'error'
-    case 'P1':
-      return 'warning'
-    case 'P2':
-      return 'info'
-    default:
-      return 'grey'
-  }
+    formDialog.visible = false
+    await refreshAll()
+  } catch (error) { showMessage(apiMessage(error, '任务保存失败'), 'error') } finally { formDialog.loading = false }
 }
-
-function addSubtask() {
-  form.subtasks.push({ title: '', done: false })
+async function claimTask(task) {
+  try { await updateSharedTask(task.id, { assignee: { id: currentUserId, name: currentUserId, email: '' } }); showMessage('任务已认领'); await loadTasks() }
+  catch (error) { showMessage(apiMessage(error, '任务认领失败'), 'error') }
 }
-
-function removeSubtask(index) {
-  if (form.subtasks.length > 1) {
-    form.subtasks.splice(index, 1)
-  }
+function openTransition(task) { transitionDialog.task = task; transitionDialog.targetStatus = nextStatus(task.status); transitionDialog.note = ''; transitionDialog.visible = true }
+async function submitTransition() {
+  if (!transitionDialog.note) return showMessage('流转备注不能为空', 'warning')
+  transitionDialog.loading = true
+  try { await transitionSharedTask(transitionDialog.task.id, { targetStatus: transitionDialog.targetStatus, note: transitionDialog.note }); transitionDialog.visible = false; showMessage('任务状态已更新'); await refreshAll() }
+  catch (error) { showMessage(apiMessage(error, '状态流转失败'), 'error') } finally { transitionDialog.loading = false }
 }
-
-function resetForm() {
-  form.title = ''
-  form.description = ''
-  form.priority = 'P2'
-  form.assignee = null
-  form.status = '待分诊'
-  form.dueDate = ''
-  form.labels = []
-  form.module = '共享运营'
-  form.acceptanceCriteria = ['输入→处理→输出可验证']
-  form.impactScope = null
-  form.ticketSource = null
-  form.taskType = '运营'
-  form.estimate = null
-  form.subtasks = [
-    { title: '梳理需求背景', done: false },
-    { title: '制定执行方案', done: false },
-  ]
-  form.dependencies = []
-  form.slaClass = 'SLA-P2'
-  form.firstResponseAt = ''
-  form.completedAt = ''
-  form.attachments = []
-  form.relatedLinks = []
-  form.milestone = ''
-  form.quarter = null
-  form.dorCheck = ['场景清晰']
-  form.riskLevel = '中'
-  form.rollbackPlan = ''
-  form.testEvidence = []
-  form.testEvidenceLinks = []
-  form.ownerTeam = null
-  form.coOwners = []
-  form.env = '测试'
-  form.releaseLink = ''
-  form.prLinks = []
-  form.ciStatus = '进行中'
-  form.eventLog = [
-    { title: '任务创建', time: new Date().toLocaleString(), actor: '当前用户' },
-  ]
-  form.reopenCount = 0
-  form.duplicateOf = ''
-  form.securityLevel = '内部'
-  form.expectedValue = ''
-  form.postmortem = ''
-  form.csat = 3
+async function removeTask(task) {
+  if (!window.confirm(`确认删除任务“${task.title}”吗？`)) return
+  try { await deleteSharedTask(task.id); showMessage('任务已删除'); await refreshAll() }
+  catch (error) { showMessage(apiMessage(error, '任务删除失败'), 'error') }
 }
-
-function simulateSubmit() {
-  if (!taskForm.value) return
-  taskForm.value.validate().then(result => {
-    if (result.valid) {
-      form.firstResponseAt = form.firstResponseAt || new Date().toISOString().slice(0, 16).replace('T', ' ')
-      if (form.status === '已完成' && !form.completedAt) {
-        form.completedAt = new Date().toISOString().slice(0, 16).replace('T', ' ')
-      }
-      form.eventLog.push({ title: '任务信息已保存', time: new Date().toLocaleString(), actor: '当前用户' })
-      alert('共享任务信息已保存（模拟）')
-    }
-  })
+function openRow(_, row) { if (row?.item) openDetail(row.item) }
+async function openDetail(task) {
+  detailDialog.visible = true; detailDialog.task = task; detailDialog.sla = null; detailDialog.comments = []; detailDialog.newComment = ''
+  try {
+    const [taskResponse, slaResponse, commentResponse] = await Promise.all([getSharedTask(task.id), getSharedTaskSla(task.id), listSharedTaskComments(task.id, { page: 1, pageSize: 50, sort: '-createdAt' })])
+    detailDialog.task = taskResponse?.data || task
+    detailDialog.sla = slaResponse?.data || null
+    detailDialog.comments = Array.isArray(commentResponse?.data) ? commentResponse.data : []
+  } catch (error) { showMessage(apiMessage(error, '任务详情加载失败'), 'error') }
 }
-</script>
-
-<script>
-export default {
-  components: {
-    SectionTitle: {
-      props: {
-        title: {
-          type: String,
-          required: true,
-        },
-      },
-      template: `
-        <div class="section-title">
-          <div class="d-flex align-center mb-3 mt-6">
-            <div class="section-indicator mr-3"></div>
-            <div class="text-subtitle-1 font-weight-medium">{{ title }}</div>
-          </div>
-        </div>
-      `,
-    },
-  },
+async function submitComment() {
+  if (!detailDialog.newComment) return showMessage('评论内容不能为空', 'warning')
+  detailDialog.commentLoading = true
+  try { await addSharedTaskComment(detailDialog.task.id, { body: detailDialog.newComment, mentions: [], attachments: [] }); detailDialog.newComment = ''; const response = await listSharedTaskComments(detailDialog.task.id, { page: 1, pageSize: 50, sort: '-createdAt' }); detailDialog.comments = Array.isArray(response?.data) ? response.data : []; showMessage('评论已添加') }
+  catch (error) { showMessage(apiMessage(error, '评论发送失败'), 'error') } finally { detailDialog.commentLoading = false }
 }
+function nextStatus(status) { const index = statusOptions.indexOf(status); return statusOptions[Math.min(index + 1, statusOptions.length - 1)] || '进行中' }
+function priorityColor(value) { return ({ P0: 'error', P1: 'warning', P2: 'primary', P3: 'default' }[value] || 'default') }
+function statusColor(value) { if (value === '已完成') return 'success'; if (value === '阻塞') return 'error'; if (value === '搁置') return 'warning'; if (['进行中', '待验收'].includes(value)) return 'primary'; return 'default' }
+function formatTime(value) { if (!value) return '-'; const date = new Date(value); return Number.isNaN(date.getTime()) ? value : date.toLocaleString('zh-CN', { hour12: false }) }
+function showMessage(text, color = 'success') { snackbar.text = text; snackbar.color = color; snackbar.show = true }
+function apiMessage(error, fallback) { return error?.response?.data?.message || error?.response?.data?.msg || fallback }
 </script>
 
 <style scoped>
-.shared-operations {
-  padding: 24px 32px 48px;
-  background: linear-gradient(180deg, #f7faff 0%, #ffffff 60%);
-}
-
-.info-card {
-  border-radius: 18px;
-  height: 100%;
-}
-
-.task-card {
-  border-radius: 18px;
-}
-
-.section-title {
-  margin-bottom: 8px;
-}
-
-.section-indicator {
-  width: 6px;
-  height: 24px;
-  border-radius: 6px;
-  background: linear-gradient(180deg, #4d7cfe 0%, #90b4ff 100%);
-}
-
-.subtask-row {
-  background-color: rgba(79, 129, 255, 0.04);
-  border-radius: 12px;
-  margin-bottom: 12px;
-  padding: 4px 8px;
-}
-
-.priority-select :deep(.v-field__outline) {
-  border-radius: 12px;
-}
-
-.chip-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-@media (max-width: 960px) {
-  .shared-operations {
-    padding: 16px;
-  }
-}
+.shared-page { min-height: 100vh; padding: 30px; color: #20322f; background: #f4f7f6; }
+.hero { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; padding: 30px 34px; border-radius: 24px; color: white; background: linear-gradient(135deg, #674b24, #a37b3e); }.hero span, .table-heading span { font-size: 11px; font-weight: 800; letter-spacing: .15em; opacity: .75; }.hero h1 { margin: 8px 0 0; font-size: 36px; }.hero p { margin: 12px 0 0; opacity: .8; }.hero-actions, .row-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+.summary-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin: 18px 0; }.summary-grid article { padding: 20px; border: 1px solid #dfe8e5; border-radius: 16px; background: white; }.summary-grid span, .summary-grid strong, .summary-grid small { display: block; }.summary-grid span, .summary-grid small { color: #778a83; }.summary-grid strong { margin: 8px 0 4px; font-size: 25px; }
+.filter-card, .table-card { border: 1px solid #dfe8e5; border-radius: 18px; background: white; }.filter-card { margin-bottom: 18px; }.table-heading { display: flex; align-items: center; justify-content: space-between; padding: 20px 22px 12px; }.table-heading strong { display: block; margin-top: 5px; font-size: 19px; }.table-heading small { color: #7b8d87; }
+.task-link { display: grid; gap: 4px; padding: 0; border: 0; color: #275e51; background: transparent; text-align: left; cursor: pointer; }.task-link small { color: #83928e; }.pagination-bar { display: flex; justify-content: center; padding: 14px 20px 22px; }.empty-state { display: grid; justify-items: center; gap: 8px; padding: 50px; color: #81918d; }.empty-state strong { color: #435b55; }
+.detail-title { display: flex; justify-content: space-between; }.detail-title small, .detail-title strong { display: block; }.detail-metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }.detail-metrics article { padding: 14px; border-radius: 12px; background: #f4f7f6; }.detail-metrics span, .detail-metrics strong { display: block; }.detail-metrics span { color: #7b8d87; font-size: 12px; }.detail-metrics strong { margin-top: 6px; }.comment-heading { display: flex; align-items: center; justify-content: space-between; }.comment-list { display: grid; gap: 10px; margin-top: 12px; }.comment-list article { padding: 14px; border-radius: 12px; background: #f4f7f6; }.comment-list header { display: flex; justify-content: space-between; }.comment-list small, .comment-empty { color: #81918d; }.comment-list p { margin: 8px 0 0; }.comment-form { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 10px; margin-top: 14px; }.comment-empty { padding: 20px 0; }
+@media (max-width: 960px) { .shared-page { padding: 16px; }.hero { align-items: flex-start; flex-direction: column; padding: 24px; }.hero h1 { font-size: 28px; }.summary-grid { grid-template-columns: repeat(2, 1fr); }.detail-metrics { grid-template-columns: repeat(2, 1fr); }.comment-form { grid-template-columns: 1fr; } }
 </style>

--- a/src/views/login/workflow/WorkflowTaskCenterView.vue
+++ b/src/views/login/workflow/WorkflowTaskCenterView.vue
@@ -4,7 +4,7 @@
       <div>
         <span>WORKFLOW TASK CENTER</span>
         <h1>工作流任务中心</h1>
-        <p>统一处理待办、查看已办，并追踪我发起的业务流程。</p>
+        <p>统一处理审批待办、查看已办，并完成发起人退回修正任务。</p>
       </div>
       <div class="hero-actions">
         <v-btn variant="tonal" prepend-icon="mdi-cash-refund" @click="router.push('/expenses')">费用报销</v-btn>
@@ -23,59 +23,47 @@
         <v-row dense>
           <v-col cols="12" md="3"><v-text-field v-model.trim="filters.tenantId" label="租户" variant="outlined" density="comfortable" hide-details /></v-col>
           <v-col cols="12" md="3"><v-text-field v-model.trim="filters.businessType" label="业务类型" variant="outlined" density="comfortable" hide-details clearable /></v-col>
-          <v-col cols="12" md="4">
-            <v-text-field v-model.trim="filters.keyword" label="任务、单据或发起人" prepend-inner-icon="mdi-magnify" variant="outlined" density="comfortable" hide-details clearable @keydown.enter="applyFilters" />
-          </v-col>
+          <v-col cols="12" md="4"><v-text-field v-model.trim="filters.keyword" label="任务、单据或发起人" prepend-inner-icon="mdi-magnify" variant="outlined" density="comfortable" hide-details clearable @keydown.enter="applyFilters" /></v-col>
           <v-col cols="12" md="2" class="filter-actions"><v-btn color="primary" block @click="applyFilters">查询</v-btn></v-col>
         </v-row>
       </v-card-text>
     </v-card>
 
-    <v-alert v-if="!operatorId" type="warning" variant="tonal" class="mb-4">
-      当前登录令牌中无法解析用户编号。任务查询仍可使用，但执行审批前需要重新登录或补充 userId。
-    </v-alert>
+    <v-alert v-if="!operatorId" type="warning" variant="tonal" class="mb-4">当前登录令牌中无法解析用户编号。任务查询仍可使用，但执行审批前需要重新登录。</v-alert>
 
     <v-card class="table-card" elevation="0">
-      <div class="table-heading">
-        <div><span>{{ viewTitle }}</span><strong>共 {{ total }} 条流程任务</strong></div>
-        <small>第 {{ page }} / {{ pageCount }} 页</small>
-      </div>
-
+      <div class="table-heading"><div><span>{{ viewTitle }}</span><strong>共 {{ total }} 条流程任务</strong></div><small>第 {{ page }} / {{ pageCount }} 页</small></div>
       <v-data-table :headers="headers" :items="items" :loading="loading" :items-per-page="size" item-value="taskId" hide-default-footer>
-        <template #item.task="{ item }"><div class="primary-cell"><strong>{{ item.taskName || item.currentNodeKey || '流程任务' }}</strong><small>{{ item.taskId }}</small></div></template>
-        <template #item.business="{ item }">
-          <button class="business-link" type="button" @click="openBusiness(item)"><strong>{{ businessTypeText(item.businessType) }}</strong><small>{{ item.businessId }}</small></button>
-        </template>
+        <template #item.task="{ item }"><div class="primary-cell"><strong>{{ item.taskName || item.currentNodeKey || '流程任务' }}</strong><small>{{ item.taskId }}</small><v-chip v-if="isResubmitTask(item)" size="x-small" color="warning" variant="tonal">发起人修正</v-chip></div></template>
+        <template #item.business="{ item }"><button class="business-link" type="button" @click="openBusiness(item)"><strong>{{ businessTypeText(item.businessType) }}</strong><small>{{ item.businessId }}</small></button></template>
         <template #item.initiatorId="{ item }">{{ item.initiatorId || '-' }}</template>
         <template #item.status="{ item }"><div class="status-stack"><v-chip size="small" variant="tonal" :color="statusColor(item.taskStatus)">{{ item.taskStatus || '-' }}</v-chip><small>流程：{{ item.instanceStatus || '-' }}</small></div></template>
         <template #item.createdAt="{ item }">{{ formatTime(item.createdAt || item.completedAt) }}</template>
         <template #item.actions="{ item }">
           <div v-if="filters.view === 'TODO'" class="row-actions">
-            <v-btn size="small" color="success" variant="tonal" @click="openAction(item, 'APPROVE')">通过</v-btn>
-            <v-btn size="small" color="error" variant="tonal" @click="openAction(item, 'REJECT')">驳回</v-btn>
-            <v-btn size="small" variant="tonal" @click="openAction(item, 'RETURN_TO_INITIATOR')">退回</v-btn>
+            <v-btn v-if="isResubmitTask(item)" size="small" color="warning" variant="tonal" prepend-icon="mdi-file-edit-outline" @click="openBusiness(item)">修改并重新提交</v-btn>
+            <template v-else>
+              <v-btn size="small" color="success" variant="tonal" @click="openAction(item, 'APPROVE')">通过</v-btn>
+              <v-btn size="small" color="error" variant="tonal" @click="openAction(item, 'REJECT')">驳回</v-btn>
+              <v-btn size="small" variant="tonal" @click="openAction(item, 'RETURN_TO_INITIATOR')">退回</v-btn>
+            </template>
           </div>
           <v-btn v-else size="small" variant="text" @click="openBusiness(item)">查看业务</v-btn>
         </template>
         <template #no-data><div class="empty-state"><v-icon size="42">mdi-clipboard-check-outline</v-icon><strong>当前视图暂无任务</strong><span>调整筛选条件或刷新后重试。</span></div></template>
       </v-data-table>
-
       <div class="pagination-bar"><v-pagination v-model="page" :length="pageCount" :total-visible="7" @update:model-value="fetchTasks" /></div>
     </v-card>
 
     <v-dialog v-model="actionDialog.visible" max-width="560" persistent>
-      <v-card>
-        <v-card-title>{{ actionText(actionDialog.action) }}任务</v-card-title>
-        <v-card-text>
-          <v-alert variant="tonal" type="info" class="mb-4">{{ actionDialog.task?.taskName }} · {{ actionDialog.task?.businessId }}</v-alert>
-          <v-text-field v-model="operatorId" label="操作人" variant="outlined" :disabled="Boolean(resolvedUserId)" />
-          <v-textarea v-model="actionDialog.comment" label="处理意见" variant="outlined" rows="4" auto-grow />
-        </v-card-text>
-        <v-card-actions><v-spacer /><v-btn variant="text" :disabled="actionDialog.loading" @click="closeAction">取消</v-btn><v-btn :color="actionColor(actionDialog.action)" :loading="actionDialog.loading" @click="submitAction">确认{{ actionText(actionDialog.action) }}</v-btn></v-card-actions>
-      </v-card>
+      <v-card><v-card-title>{{ actionText(actionDialog.action) }}任务</v-card-title><v-card-text>
+        <v-alert variant="tonal" type="info" class="mb-4">{{ actionDialog.task?.taskName }} · {{ actionDialog.task?.businessId }}</v-alert>
+        <v-text-field v-model="operatorId" label="操作人" variant="outlined" :disabled="Boolean(resolvedUserId)" />
+        <v-textarea v-model="actionDialog.comment" label="处理意见" variant="outlined" rows="4" auto-grow />
+      </v-card-text><v-card-actions><v-spacer /><v-btn variant="text" :disabled="actionDialog.loading" @click="closeAction">取消</v-btn><v-btn :color="actionColor(actionDialog.action)" :loading="actionDialog.loading" @click="submitAction">确认{{ actionText(actionDialog.action) }}</v-btn></v-card-actions></v-card>
     </v-dialog>
 
-    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="2200">{{ snackbar.text }}</v-snackbar>
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="2600">{{ snackbar.text }}</v-snackbar>
   </main>
 </template>
 
@@ -96,14 +84,13 @@ const size = ref(20)
 const filters = reactive({ tenantId: 'default', view: 'TODO', businessType: '', keyword: '' })
 const snackbar = reactive({ show: false, text: '', color: 'success' })
 const actionDialog = reactive({ visible: false, loading: false, task: null, action: 'APPROVE', comment: '' })
-
 const headers = [
-  { title: '任务', key: 'task', minWidth: 210 },
+  { title: '任务', key: 'task', minWidth: 220 },
   { title: '业务单据', key: 'business', minWidth: 190 },
   { title: '发起人', key: 'initiatorId', width: 130 },
-  { title: '状态', key: 'status', width: 150 },
+  { title: '状态', key: 'status', width: 170 },
   { title: '创建/完成时间', key: 'createdAt', width: 170 },
-  { title: '操作', key: 'actions', sortable: false, minWidth: 220 },
+  { title: '操作', key: 'actions', sortable: false, minWidth: 240 },
 ]
 const pageCount = computed(() => Math.max(1, Math.ceil(total.value / size.value)))
 const viewTitle = computed(() => ({ TODO: '我的待办', DONE: '我的已办', INITIATED: '我发起的' }[filters.view] || '流程任务'))
@@ -119,45 +106,43 @@ async function fetchTasks() {
     const data = response?.data || {}
     items.value = Array.isArray(data.items) ? data.items : []
     total.value = Number(data.total || 0)
-  } catch (error) {
-    items.value = []
-    total.value = 0
-    showMessage(error?.response?.data?.message || '工作流任务加载失败', 'error')
-  } finally {
-    loading.value = false
-  }
+  } catch (error) { items.value = []; total.value = 0; showMessage(apiMessage(error, '工作流任务加载失败'), 'error') } finally { loading.value = false }
 }
 
 function applyFilters() { page.value = 1; fetchTasks() }
-function openAction(task, action) { actionDialog.task = task; actionDialog.action = action; actionDialog.comment = ''; actionDialog.visible = true }
+function openAction(task, action) {
+  if (isResubmitTask(task)) { openBusiness(task); return }
+  actionDialog.task = task; actionDialog.action = action; actionDialog.comment = ''; actionDialog.visible = true
+}
 function closeAction() { actionDialog.visible = false; actionDialog.task = null; actionDialog.comment = '' }
-
 async function submitAction() {
   if (!operatorId.value) return showMessage('无法识别当前操作人，请重新登录', 'warning')
   actionDialog.loading = true
   try {
     await actOnWorkflowTask(actionDialog.task.taskId, { action: actionDialog.action, operatorId: operatorId.value, comment: actionDialog.comment || undefined, variables: {} })
     showMessage(`任务已${actionText(actionDialog.action)}`)
-    actionDialog.loading = false
     closeAction()
     await fetchTasks()
-  } catch (error) {
-    showMessage(error?.response?.data?.message || '任务处理失败', 'error')
-  } finally {
-    actionDialog.loading = false
-  }
+  } catch (error) { showMessage(apiMessage(error, '任务处理失败'), 'error') } finally { actionDialog.loading = false }
 }
 
+function isResubmitTask(item) {
+  const node = String(item?.currentNodeKey || '').toUpperCase()
+  const name = String(item?.taskName || '')
+  const instance = String(item?.instanceStatus || '').toUpperCase()
+  return node === '__RESUBMIT__' || instance === 'WAITING_RESUBMIT' || name.includes('修正') || name.includes('重新提交')
+}
 function openBusiness(item) {
-  if ((item.businessType || '').toUpperCase().includes('EXPENSE') && item.businessId) return router.push({ path: '/expenses', query: { expenseId: item.businessId } })
+  if (String(item?.businessType || '').toUpperCase().includes('EXPENSE') && item.businessId) return router.push({ path: '/expenses', query: { expenseId: item.businessId } })
   showMessage('该业务详情页尚未接入', 'info')
 }
-function businessTypeText(value) { if (!value) return '业务流程'; return value.toUpperCase().includes('EXPENSE') ? '费用报销' : value }
-function statusColor(value) { const status = (value || '').toUpperCase(); if (['COMPLETED', 'APPROVED', 'DONE'].includes(status)) return 'success'; if (['REJECTED', 'CANCELLED', 'FAILED'].includes(status)) return 'error'; if (['PENDING', 'TODO', 'ACTIVE', 'PROCESSING'].includes(status)) return 'primary'; return 'default' }
+function businessTypeText(value) { if (!value) return '业务流程'; return String(value).toUpperCase().includes('EXPENSE') ? '费用报销' : value }
+function statusColor(value) { const v = String(value || '').toUpperCase(); if (['COMPLETED', 'APPROVED', 'DONE'].includes(v)) return 'success'; if (['REJECTED', 'CANCELLED', 'FAILED'].includes(v)) return 'error'; if (['WAITING_RESUBMIT', 'RETURNED'].includes(v)) return 'warning'; if (['PENDING', 'TODO', 'ACTIVE', 'PROCESSING'].includes(v)) return 'primary'; return 'default' }
 function actionText(action) { return ({ APPROVE: '通过', REJECT: '驳回', RETURN_TO_INITIATOR: '退回发起人' }[action] || action) }
 function actionColor(action) { return action === 'APPROVE' ? 'success' : action === 'REJECT' ? 'error' : 'warning' }
 function formatTime(value) { if (!value) return '-'; const date = new Date(value); return Number.isNaN(date.getTime()) ? value : date.toLocaleString('zh-CN', { hour12: false }) }
 function showMessage(text, color = 'success') { snackbar.text = text; snackbar.color = color; snackbar.show = true }
+function apiMessage(error, fallback) { return error?.response?.data?.message || error?.response?.data?.msg || fallback }
 </script>
 
 <style scoped>


### PR DESCRIPTION
## What changed

- add workflow attachment upload, confirmation, listing, preview, and deletion APIs
- calculate SHA-256 in the browser and upload invoice files through the workflow signed URL flow
- require at least one confirmed clean `INVOICE` attachment before expense submission
- allow `RETURNED` expense documents to be edited and resubmitted
- show cancellation only for backend-supported `APPROVING` and `RETURNED` states
- route workflow `__RESUBMIT__` / `WAITING_RESUBMIT` tasks to the expense correction page instead of approval actions
- replace the shared-operations mock form with a real task pool backed by `/shared-cloud` APIs
- support task search, create, edit, claim, transition, delete, SLA detail, summary metrics, and comments
- add focused frontend CI

## Validation

Passed on `53c0cfff380dd0b32cafc4e449f8c3fc1c39f0e1`:

- P0 Business Closure Web CI
- Workflow Expense Web CI
- `npm ci`
- `npm run build`

## Target

Merge into `dev` after browser-level attachment upload and shared-task API smoke testing.