### PR TITLE
chore: verify one-time branch cleanup

### DIFF
--- a/.github/branch-cleanup-trigger.txt
+++ b/.github/branch-cleanup-trigger.txt
@@ -1,0 +1,1 @@
+Verify that only dev and main remain after one-time branch cleanup.


### PR DESCRIPTION
Temporary PR used only to verify the repository branch list. The cleanup workflow should find `dev`, `main`, and this temporary branch, then delete the temporary branch.