### PR TITLE
feat(portal): replace demo metrics with live services

### DIFF
--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -1,0 +1,9 @@
+import request from '@/utils/request'
+
+export function getFinanceDashboardOverview(params = {}) {
+  return request.get('/finance-dashboard/overview', { params })
+}
+
+export function getCurrentUserProfile() {
+  return request.get('/user/me')
+}

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -8,7 +8,7 @@ function localPeriod() {
 export function getFinanceDashboardOverview(params = {}) {
   const utcPeriod = new Date().toISOString().slice(0, 7)
   const requestedPeriod = params.period || localPeriod()
-  return request.get('/finance-dashboard/overview', {
+  return request.get('/voucher/dashboard/overview', {
     params: {
       ...params,
       period: requestedPeriod === utcPeriod ? localPeriod() : requestedPeriod,

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -1,7 +1,19 @@
 import request from '@/utils/request'
 
+function localPeriod() {
+  const now = new Date()
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+}
+
 export function getFinanceDashboardOverview(params = {}) {
-  return request.get('/finance-dashboard/overview', { params })
+  const utcPeriod = new Date().toISOString().slice(0, 7)
+  const requestedPeriod = params.period || localPeriod()
+  return request.get('/finance-dashboard/overview', {
+    params: {
+      ...params,
+      period: requestedPeriod === utcPeriod ? localPeriod() : requestedPeriod,
+    },
+  })
 }
 
 export function getCurrentUserProfile() {

--- a/src/api/workflow.js
+++ b/src/api/workflow.js
@@ -1,8 +1,15 @@
 import request from '@/utils/request'
-import { newRequestId } from '@/utils/currentUser'
+import { getCurrentTenantId, newRequestId } from '@/utils/currentUser'
 
-export function listWorkflowTaskCenter(params) {
-  return request.get('/workflow/task-center', { params })
+export function listWorkflowTaskCenter(params = {}) {
+  return request.get('/workflow/task-center', {
+    params: {
+      ...params,
+      tenantId: params.tenantId && params.tenantId !== 'default'
+        ? params.tenantId
+        : getCurrentTenantId(params.tenantId || 'default'),
+    },
+  })
 }
 
 export function getWorkflowTask(taskId) {

--- a/src/utils/currentUser.js
+++ b/src/utils/currentUser.js
@@ -9,25 +9,41 @@ function decodeBase64Url(value) {
   )
 }
 
+function getJwtPayload() {
+  const token = localStorage.getItem('token')
+  if (!token || token.split('.').length < 2) return null
+
+  try {
+    return JSON.parse(decodeBase64Url(token.split('.')[1]))
+  } catch (error) {
+    console.warn('Unable to decode current JWT payload', error)
+    return null
+  }
+}
+
 export function getCurrentUserId() {
   const stored = localStorage.getItem('userId') || localStorage.getItem('username')
   if (stored) return stored
 
-  const token = localStorage.getItem('token')
-  if (!token || token.split('.').length < 2) return ''
+  const payload = getJwtPayload()
+  return payload?.userId
+    || payload?.user_id
+    || payload?.id
+    || payload?.sub
+    || payload?.username
+    || payload?.preferred_username
+    || ''
+}
 
-  try {
-    const payload = JSON.parse(decodeBase64Url(token.split('.')[1]))
-    return payload.userId
-      || payload.user_id
-      || payload.sub
-      || payload.username
-      || payload.preferred_username
-      || ''
-  } catch (error) {
-    console.warn('Unable to resolve current user from JWT', error)
-    return ''
-  }
+export function getCurrentTenantId(fallback = 'default') {
+  const stored = localStorage.getItem('tenantId')
+  if (stored) return stored
+
+  const payload = getJwtPayload()
+  return payload?.tenantId
+    || payload?.tenant_id
+    || payload?.tenant
+    || fallback
 }
 
 export function newRequestId(prefix = 'web') {

--- a/src/views/login/PlatformPortalView.vue
+++ b/src/views/login/PlatformPortalView.vue
@@ -21,7 +21,10 @@
       </nav>
 
       <div class="side-spacer" />
-      <div class="platform-status"><span class="status-dot" /><div><strong>平台运行正常</strong><small>核心服务可用</small></div></div>
+      <div class="platform-status" :class="platformState">
+        <span class="status-dot" />
+        <div><strong>{{ platformStatus.title }}</strong><small>{{ platformStatus.detail }}</small></div>
+      </div>
       <button type="button" class="logout-link" @click="handleLogout"><SwitchButton class="nav-icon" /><span>退出登录</span></button>
     </aside>
 
@@ -30,8 +33,14 @@
         <div class="page-title"><span>{{ currentDate }}</span><strong>{{ currentPage.title }}</strong><small>{{ currentPage.subtitle }}</small></div>
         <div class="top-actions">
           <button type="button" class="top-action" title="新建费用报销" @click="navigateTo('/expenses')"><Plus /></button>
-          <button type="button" class="top-action notification-button" title="消息中心" @click="navigateTo('/notifications')"><Bell /><span class="notice-badge" /></button>
-          <button type="button" class="profile-button" @click="navigateTo('/personal')"><span class="avatar">M</span><span class="profile-copy"><strong>当前用户</strong><small>Matrix 平台</small></span></button>
+          <button type="button" class="top-action notification-button" title="消息中心" @click="navigateTo('/notifications')">
+            <Bell />
+            <span v-if="unreadCount > 0" class="notice-badge">{{ unreadLabel }}</span>
+          </button>
+          <button type="button" class="profile-button" @click="navigateTo('/personal')">
+            <span class="avatar">{{ userInitial }}</span>
+            <span class="profile-copy"><strong>{{ currentUser.displayName || '当前用户' }}</strong><small>{{ profileSubtitle }}</small></span>
+          </button>
         </div>
       </header>
 
@@ -66,10 +75,14 @@
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { getFinanceDashboardOverview, getCurrentUserProfile } from '@/api/dashboard'
+import { getUnreadCount } from '@/api/im'
 import { getApps, getWorkbench } from '@/api/platform'
+import { listWorkflowTaskCenter } from '@/api/workflow'
 import ApplicationCenterPanel from '@/components/platform/ApplicationCenterPanel.vue'
 import WorkbenchPanel from '@/components/platform/WorkbenchPanel.vue'
 import { clearToken } from '@/utils/auth'
+import { getCurrentUserId } from '@/utils/currentUser'
 import { resolveMatrixIcon } from '@/utils/matrixIcons'
 import {
   Bell,
@@ -77,7 +90,6 @@ import {
   ChatDotRound,
   Connection,
   Cpu,
-  DataAnalysis,
   Files,
   Grid,
   House,
@@ -92,8 +104,6 @@ import {
   SwitchButton,
   Tickets,
   TrendCharts,
-  Upload,
-  User,
   Wallet,
 } from '@element-plus/icons-vue'
 
@@ -102,6 +112,9 @@ const router = useRouter()
 const snackbar = ref({ show: false, text: '', type: 'info' })
 let toastTimer = null
 const activeNav = ref(resolveInternalView(route.query.view))
+const platformState = ref('loading')
+const currentUser = ref({ userId: getCurrentUserId(), displayName: '', tenantId: 'default' })
+const unreadCount = ref(0)
 
 const navItems = [
   { key: 'workbench', label: '工作台', icon: House, internal: true },
@@ -120,26 +133,25 @@ const pageMap = {
 }
 const currentPage = computed(() => pageMap[activeNav.value] || pageMap.workbench)
 const currentDate = computed(() => new Intl.DateTimeFormat('zh-CN', { month: 'long', day: 'numeric', weekday: 'long' }).format(new Date()))
+const currentPeriod = computed(() => new Date().toISOString().slice(0, 7))
+const userInitial = computed(() => Array.from(currentUser.value.displayName || currentUser.value.userId || 'M')[0] || 'M')
+const profileSubtitle = computed(() => {
+  if (currentUser.value.departmentName) return currentUser.value.departmentName
+  if (currentUser.value.employeeNumber) return `工号 ${currentUser.value.employeeNumber}`
+  return currentUser.value.tenantId && currentUser.value.tenantId !== 'default' ? `租户 ${currentUser.value.tenantId}` : 'Matrix 平台'
+})
+const unreadLabel = computed(() => unreadCount.value > 99 ? '99+' : String(unreadCount.value))
+const platformStatus = computed(() => ({
+  loading: { title: '平台状态检查中', detail: '正在加载核心服务数据' },
+  healthy: { title: '平台运行正常', detail: '核心服务数据已同步' },
+  degraded: { title: '部分服务不可用', detail: '页面已隐藏不可靠数据' },
+  unavailable: { title: '核心服务不可用', detail: '请检查网关和服务状态' },
+}[platformState.value] || { title: '平台状态未知', detail: '请稍后刷新' }))
 
-const defaultHeroMetrics = [
-  { label: '月结进度', value: '82%', hint: '较昨日 +11%' },
-  { label: '待我处理', value: '6', hint: '进入审批中心处理' },
-  { label: '本月凭证', value: '1,280', hint: '自动生成 64%' },
-]
-const defaultTodos = [
-  { title: '处理流程待办', desc: '查看费用报销和其他审批任务', path: '/workflow/tasks', priority: 'high' },
-  { title: '确认月结检查项', desc: '总账模块还有 3 项需确认', path: '/ledger/month-end-close-workbench', priority: 'medium' },
-  { title: '复核应付账龄预警', desc: '2 家供应商超过信用期', path: '/payable/aging-credit', priority: 'low' },
-]
-const defaultRecentItems = [
-  { title: '费用报销', detail: '创建或查询报销单', time: '常用', path: '/expenses', icon: Tickets },
-  { title: '资产负债表', detail: '本期财务报表', time: '10:24', path: '/ledger/balance-sheet', icon: DataAnalysis },
-  { title: '往来对账单', detail: '客户与供应商余额核对', time: '周五', path: '/ledger/counterparty-statement', icon: Files },
-]
-const defaultNotices = [
-  { tag: '流程', type: 'platform', title: '统一审批中心已接入', desc: '支持我的待办、已办、我发起和审批处理。' },
-  { tag: '费用', type: 'finance', title: '费用报销已接入工作流', desc: '支持草稿、提交、取消和审批详情。' },
-  { tag: 'IM', type: 'knowledge', title: '消息中心与推送管理已拆分', desc: '个人收件箱和平台管理职责更加清晰。' },
+const emptyHeroMetrics = [
+  { label: '月结进度', value: '—', hint: '暂无月结检查数据' },
+  { label: '待我处理', value: '—', hint: '暂无工作流待办数据' },
+  { label: '本月凭证', value: '—', hint: '暂无凭证汇总数据' },
 ]
 const defaultQuickActions = [
   { label: '新增报销', icon: Plus, path: '/expenses' },
@@ -149,7 +161,6 @@ const defaultQuickActions = [
   { label: '消息中心', icon: Message, path: '/notifications' },
   { label: '调度中心', icon: Calendar, path: '/scheduler/jobs' },
 ]
-
 const defaultApps = [
   { key: 'finance', name: '财务系统', desc: '覆盖总账、凭证、应收应付、报表、期末处理和财务基础资料。', meta: '核心业务系统', status: '已上线', category: 'business', tags: ['总账', '应收应付', '报表', '月结'], icon: Wallet, accent: '#15745f', path: '/finance', newPage: true, featured: true, available: true, order: 10 },
   { key: 'workflow', name: '审批与流程中心', desc: '统一处理待办、查看已办，并追踪我发起的业务流程。', meta: '流程协同平台', status: '已上线', category: 'business', tags: ['审批流', '待办', '流程追踪'], icon: Operation, accent: '#a36a28', path: '/workflow/tasks', featured: true, available: true, order: 20 },
@@ -166,10 +177,10 @@ const defaultApps = [
   { key: 'scheduler-operations', name: '调度运行与可靠性中心', desc: '集中查看调度执行、失败记录、补偿任务和异常恢复操作。', meta: '运行保障', status: '已上线', category: 'platform', tags: ['运行中心', '补偿', '异常恢复'], icon: Cpu, accent: '#4c758a', path: '/scheduler/operations', available: true, order: 130 },
 ]
 
-const heroMetrics = ref(defaultHeroMetrics)
-const todos = ref(defaultTodos)
-const recentItems = ref(defaultRecentItems)
-const notices = ref(defaultNotices)
+const heroMetrics = ref(emptyHeroMetrics)
+const todos = ref([])
+const recentItems = ref([])
+const notices = ref([])
 const quickActions = ref(defaultQuickActions)
 const apps = ref(defaultApps)
 
@@ -177,31 +188,101 @@ watch(() => route.query.view, value => { activeNav.value = resolveInternalView(v
 onMounted(loadPortalData)
 
 async function loadPortalData() {
-  const [workbenchResult, appsResult] = await Promise.allSettled([getWorkbench(), getApps()])
+  platformState.value = 'loading'
+  const results = await Promise.allSettled([
+    getWorkbench(),
+    getApps(),
+    getFinanceDashboardOverview({ period: currentPeriod.value }),
+    listWorkflowTaskCenter({ tenantId: currentUser.value.tenantId || 'default', view: 'TODO', page: 1, size: 1 }),
+    getCurrentUserProfile(),
+    getUnreadCount(),
+  ])
+  const [workbenchResult, appsResult, financeResult, workflowResult, userResult, unreadResult] = results
+
+  if (userResult.status === 'fulfilled') {
+    currentUser.value = { ...currentUser.value, ...unwrapResponse(userResult.value) }
+  }
+  if (unreadResult.status === 'fulfilled') {
+    unreadCount.value = normalizeUnreadCount(unreadResult.value)
+  } else {
+    unreadCount.value = 0
+  }
+
   if (workbenchResult.status === 'fulfilled') {
     const data = unwrapResponse(workbenchResult.value)
-    heroMetrics.value = hydrateList(data.heroMetrics, hydrateMetric, defaultHeroMetrics)
-    todos.value = hydrateList(data.todos, hydrateTodo, defaultTodos)
-    recentItems.value = hydrateList(data.recentItems, hydrateRecent, defaultRecentItems)
-    notices.value = hydrateList(data.notices, hydrateNotice, defaultNotices)
+    todos.value = hydrateList(data.todos, hydrateTodo)
+    recentItems.value = hydrateList(data.recentItems, hydrateRecent)
+    notices.value = hydrateList(data.notices, hydrateNotice)
     quickActions.value = hydrateList(data.quickActions, hydrateQuickAction, defaultQuickActions)
+  } else {
+    todos.value = []
+    recentItems.value = []
+    notices.value = []
+    quickActions.value = defaultQuickActions
   }
+
   if (appsResult.status === 'fulfilled') {
     const remoteApps = unwrapResponse(appsResult.value)
-    apps.value = mergeAppCatalog(Array.isArray(remoteApps) ? remoteApps : [])
+    apps.value = Array.isArray(remoteApps) && remoteApps.length ? mergeAppCatalog(remoteApps) : defaultApps
+  } else {
+    apps.value = defaultApps
   }
+
+  const financeData = financeResult.status === 'fulfilled' ? unwrapResponse(financeResult.value) : null
+  const workflowData = workflowResult.status === 'fulfilled' ? unwrapResponse(workflowResult.value) : null
+  heroMetrics.value = buildHeroMetrics(financeData, workflowData)
+
+  const failureCount = results.filter(result => result.status === 'rejected').length
+  platformState.value = failureCount === 0 ? 'healthy' : failureCount < results.length ? 'degraded' : 'unavailable'
+}
+
+function buildHeroMetrics(finance, workflow) {
+  const progress = nullableNumber(finance?.monthCloseProgress)
+  const monthVoucherCount = nullableNumber(finance?.monthVoucherCount)
+  const postedVoucherCount = nullableNumber(finance?.postedVoucherCount)
+  const todoCount = nullableNumber(workflow?.total)
+  return [
+    {
+      label: '月结进度',
+      value: progress == null ? '—' : `${progress}%`,
+      hint: finance ? buildCloseHint(finance) : '月结服务暂不可用',
+    },
+    {
+      label: '待我处理',
+      value: todoCount == null ? '—' : formatCount(todoCount),
+      hint: todoCount == null ? '工作流服务暂不可用' : todoCount > 0 ? '进入审批中心处理' : '当前没有待办任务',
+    },
+    {
+      label: '本月凭证',
+      value: monthVoucherCount == null ? '—' : formatCount(monthVoucherCount),
+      hint: monthVoucherCount == null ? '凭证服务暂不可用' : `已过账 ${formatCount(postedVoucherCount || 0)} 张`,
+    },
+  ]
+}
+
+function buildCloseHint(finance) {
+  const passed = nullableNumber(finance.monthClosePassedCount)
+  const total = nullableNumber(finance.monthCloseTotalCount)
+  const blocking = nullableNumber(finance.monthCloseBlockingCount)
+  if (total != null && total > 0) return `${passed || 0}/${total} 项通过${blocking > 0 ? `，${blocking} 项阻塞` : ''}`
+  return Array.isArray(finance.warnings) && finance.warnings.length ? finance.warnings[0] : '暂无月结检查项'
 }
 
 function unwrapResponse(response) {
   if (response?.code && response.code !== 200) throw new Error(response.message || 'platform api error')
-  return response?.data || response || {}
+  return response?.data ?? response ?? {}
 }
-function hydrateList(source, mapper, fallback) { return Array.isArray(source) && source.length ? source.map(mapper) : fallback }
-function hydrateMetric(item) { return { label: item.label || item.name || item.title, value: item.value, hint: item.hint } }
+function hydrateList(source, mapper, fallback = []) { return Array.isArray(source) && source.length ? source.map(mapper) : fallback }
 function hydrateTodo(item) { return { title: item.title || item.name || item.label, desc: item.desc || item.description || item.detail, path: item.path || item.routePath, priority: item.priority } }
 function hydrateRecent(item) { return { title: item.title || item.name || item.label, detail: item.detail || item.desc || item.description, time: item.time || item.value, path: item.path || item.routePath, icon: resolveMatrixIcon(item.iconKey, Files) } }
 function hydrateNotice(item) { return { tag: item.tag, type: item.type, title: item.title || item.name || item.label, desc: item.desc || item.description || item.detail } }
 function hydrateQuickAction(item) { return { label: item.label || item.name || item.title, icon: resolveMatrixIcon(item.iconKey, Grid), path: item.path || item.routePath } }
+function nullableNumber(value) { if (value === null || value === undefined || value === '') return null; const result = Number(value); return Number.isFinite(result) ? result : null }
+function formatCount(value) { return new Intl.NumberFormat('zh-CN').format(Number(value || 0)) }
+function normalizeUnreadCount(value) {
+  const data = value?.data ?? value
+  return Math.max(0, nullableNumber(data?.totalUnread ?? data?.unreadCount ?? data?.count ?? data) || 0)
+}
 
 function normalizeRemoteKey(item) {
   const key = item.key || ''
@@ -232,14 +313,14 @@ function mergeAppCatalog(remoteApps) {
     if (target) {
       Object.assign(target, {
         ...remote,
-        name: target.name,
-        desc: target.desc,
-        meta: target.meta,
+        name: remote.name || target.name,
+        desc: remote.desc || target.desc,
+        meta: remote.meta || target.meta,
         category: target.category,
         tags: target.tags,
         icon: raw.iconKey ? remote.icon : target.icon,
         accent: remote.accent || target.accent,
-        path: target.path,
+        path: remote.path || target.path,
         featured: target.featured || remote.featured,
         order: target.order,
       })
@@ -294,14 +375,17 @@ function showToast(text, type = 'info') {
 .nav-icon, .nav-item :deep(svg), .logout-link :deep(svg) { width: 19px; height: 19px; }
 .side-spacer { flex: 1; }
 .platform-status { display: grid; grid-template-columns: 10px minmax(0, 1fr); gap: 10px; align-items: center; margin: 18px 4px; padding: 14px; border: 1px solid #e3ece9; border-radius: 14px; background: #f8fbfa; }
-.status-dot { width: 9px; height: 9px; border-radius: 999px; background: #39a77f; box-shadow: 0 0 0 5px rgba(57,167,127,.11); }
+.status-dot { width: 9px; height: 9px; border-radius: 999px; background: #8b9794; box-shadow: 0 0 0 5px rgba(139,151,148,.11); }
+.platform-status.healthy .status-dot { background: #39a77f; box-shadow: 0 0 0 5px rgba(57,167,127,.11); }
+.platform-status.degraded .status-dot { background: #d69b35; box-shadow: 0 0 0 5px rgba(214,155,53,.12); }
+.platform-status.unavailable .status-dot { background: #d75c58; box-shadow: 0 0 0 5px rgba(215,92,88,.12); }
 .platform-status strong, .platform-status small { display: block; }
 .platform-status strong { font-size: 12px; }.platform-status small { margin-top: 3px; color: #879591; font-size: 10px; }
 .logout-link { color: #8a5b5b; }.workspace { min-width: 0; flex: 1; }
 .topbar { position: sticky; z-index: 20; top: 0; display: flex; align-items: center; justify-content: space-between; min-height: 82px; gap: 24px; padding: 14px 30px; border-bottom: 1px solid rgba(218,230,226,.9); background: rgba(247,250,249,.9); backdrop-filter: blur(16px); }
 .page-title span, .page-title strong, .page-title small { display: block; }.page-title span { color: #7e8d89; font-size: 11px; }.page-title strong { margin-top: 3px; font-size: 20px; }.page-title small { margin-top: 2px; color: #87938f; font-size: 11px; }
 .top-actions { display: flex; align-items: center; gap: 9px; }.top-action { position: relative; display: grid; width: 38px; height: 38px; place-items: center; border: 1px solid #dbe7e3; border-radius: 12px; color: #56716a; background: #fff; cursor: pointer; }.top-action svg { width: 18px; height: 18px; }
-.notice-badge { position: absolute; top: 7px; right: 7px; width: 7px; height: 7px; border: 2px solid #fff; border-radius: 999px; background: #e45c58; }
+.notice-badge { position: absolute; top: -5px; right: -5px; display: grid; min-width: 19px; height: 19px; padding: 0 5px; place-items: center; border: 2px solid #fff; border-radius: 999px; color: #fff; background: #e45c58; font-size: 9px; font-weight: 800; line-height: 1; }
 .profile-button { display: flex; align-items: center; gap: 9px; min-height: 42px; padding: 3px 10px 3px 4px; border: 0; border-radius: 14px; color: inherit; background: transparent; cursor: pointer; }.avatar { display: grid; width: 36px; height: 36px; place-items: center; border-radius: 12px; color: #fff; background: #2f7f6b; font-weight: 800; }.profile-copy strong, .profile-copy small { display: block; text-align: left; }.profile-copy strong { font-size: 12px; }.profile-copy small { color: #87938f; font-size: 10px; }
 .page-content { max-width: 1600px; margin: 0 auto; padding: 28px 30px 42px; }
 .settings-view { display: grid; gap: 24px; }.settings-hero { display: grid; justify-items: start; padding: 42px; border-radius: 28px; color: #fff; background: linear-gradient(135deg, #273b45, #365a61); }.settings-icon { width: 34px; height: 34px; margin-bottom: 18px; }.settings-hero span { color: #b9d5d2; font-size: 11px; font-weight: 800; letter-spacing: .16em; }.settings-hero h1 { margin: 9px 0 0; font-size: 38px; }.settings-hero p { max-width: 640px; margin: 14px 0 0; color: rgba(255,255,255,.72); }


### PR DESCRIPTION
## What changed

- load finance dashboard metrics from the real backend overview endpoint
- load the current workflow TODO count, current user profile, and IM unread count
- resolve workflow tenant identity from trusted JWT claims instead of assuming `default`
- use the browser-local accounting month rather than a UTC-derived month at timezone boundaries
- replace demonstration business numbers with `—` and explicit unavailable states when services fail
- stop fabricating TODO, recent-item, and notice records when the platform configuration API is empty
- show real user identity, notification count, and degraded platform status
- allow backend application metadata to override local app names, descriptions, paths, and statuses

## Why

The portal previously showed fixed values such as 82% month close progress and 1,280 vouchers. Those values looked authoritative even when no backend data was available.

## Backend dependency

- `micor-cjj-spec/matrix#52`

## Validation

Passed on `3bba21fbb9beeee9eec09e6f289f2a4704b1bc40`:

- Workflow Expense Web CI
- P0 Business Closure Web CI
- full Vite production build

The PR remains draft until a browser smoke test is run against the companion backend branch and real database data.