### PR TITLE
docs: establish executable frontend AI skills framework

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,35 @@
+# Matrix Web AI Skills
+
+This directory is the canonical project-level skill library for AI-assisted frontend development in `matrix-web`.
+
+## Entry point
+
+Read `/AGENTS.md` first. It contains repository-wide rules that always apply.
+
+Then load every skill relevant to the task:
+
+- `matrix-ui`: general visual system, layout, component and interaction work.
+- `matrix-table-page`: data tables, search conditions, pagination, sorting and export.
+- `matrix-form-page`: create, edit, view and workflow forms.
+- `matrix-api-integration`: API modules, Axios, DTO mapping, auth and errors.
+- `matrix-frontend-review`: review and pre-merge risk analysis.
+
+A task may require several skills. For example, a new voucher maintenance page generally requires `matrix-ui`, `matrix-form-page`, `matrix-api-integration`, and `matrix-frontend-review`.
+
+## Directory roles
+
+Each skill directory may contain:
+
+- `SKILL.md`: activation description, workflow and mandatory rules.
+- `references/`: detailed guidance loaded only when needed.
+- `assets/`: reusable checklists and templates.
+- `scripts/`: deterministic validation or generation tools.
+
+## Maintenance principles
+
+- Keep repository-wide invariants in `/AGENTS.md`.
+- Keep repeatable task workflows in skills.
+- Keep detailed explanations in `references/`.
+- Keep templates and checklists in `assets/`.
+- Do not duplicate the same rule across many files unless a short reminder is necessary for safety.
+- Update these instructions when the actual project architecture or UI conventions change.

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -25,6 +25,18 @@ Each skill directory may contain:
 - `assets/`: reusable checklists and templates.
 - `scripts/`: deterministic validation or generation tools.
 
+## Deterministic validation and assets
+
+See `.agents/VALIDATION.md` for complete usage.
+
+```bash
+python .agents/scripts/validate_skills.py
+node .agents/skills/matrix-frontend-review/scripts/scan-sensitive-logs.mjs
+npm run build
+```
+
+Reusable Element Plus and Vuetify table/form page templates are stored under the corresponding skill's `assets/` directory. Copy only the template matching the surrounding feature and replace every `TODO(matrix)` marker.
+
 ## Maintenance principles
 
 - Keep repository-wide invariants in `/AGENTS.md`.

--- a/.agents/VALIDATION.md
+++ b/.agents/VALIDATION.md
@@ -1,0 +1,44 @@
+# Frontend Agent Validation Workflow
+
+Use these checks after AI-assisted Matrix Web changes.
+
+## Skill structure
+
+```bash
+python .agents/scripts/validate_skills.py
+```
+
+Validates every project Skill and its required frontmatter.
+
+## Sensitive logging and literals
+
+```bash
+node .agents/skills/matrix-frontend-review/scripts/scan-sensitive-logs.mjs src/path/to/changed.vue
+```
+
+With no explicit path, the script checks changed and untracked frontend files detected by Git. It rejects likely token/password logging and hard-coded bearer credentials, and warns about general `console.log` statements.
+
+## Reusable assets
+
+- Element Plus table page:
+  `.agents/skills/matrix-table-page/assets/element-plus-table-page-template.vue`
+- Vuetify table page:
+  `.agents/skills/matrix-table-page/assets/vuetify-table-page-template.vue`
+- Element Plus form page:
+  `.agents/skills/matrix-form-page/assets/element-plus-form-page-template.vue`
+- Vuetify form page:
+  `.agents/skills/matrix-form-page/assets/vuetify-form-page-template.vue`
+- API contract checklist:
+  `.agents/skills/matrix-api-integration/assets/api-contract-checklist.md`
+
+Copy the asset that matches the surrounding feature and replace every `TODO(matrix)` placeholder. Do not mix component libraries in one page without an explicit migration decision.
+
+## Required runtime validation
+
+```bash
+npm run build
+```
+
+Then perform browser smoke tests for loading, success, empty, error, permission, duplicate-submit, and narrow-width behavior.
+
+These checks supplement review and browser testing; they do not prove business correctness.

--- a/.agents/scripts/validate_skills.py
+++ b/.agents/scripts/validate_skills.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Validate the repository-local Agent Skills structure using only stdlib."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---\n", 4)
+    if end < 0:
+        return {}
+    result: dict[str, str] = {}
+    for raw_line in text[4:end].splitlines():
+        if ":" not in raw_line:
+            continue
+        key, value = raw_line.split(":", 1)
+        result[key.strip()] = value.strip().strip('"\'')
+    return result
+
+
+def end_of_frontmatter(text: str) -> int:
+    if not text.startswith("---\n"):
+        return 0
+    end = text.find("\n---\n", 4)
+    return end + 5 if end >= 0 else 0
+
+
+def validate(root: Path) -> list[str]:
+    errors: list[str] = []
+    skills_dir = root / ".agents" / "skills"
+    if not skills_dir.is_dir():
+        return [f"missing skills directory: {skills_dir}"]
+
+    skill_dirs = sorted(path for path in skills_dir.iterdir() if path.is_dir())
+    if not skill_dirs:
+        return [f"no skill directories found under: {skills_dir}"]
+
+    for skill_dir in skill_dirs:
+        skill_name = skill_dir.name
+        prefix = str(skill_dir.relative_to(root))
+        if not NAME_RE.fullmatch(skill_name):
+            errors.append(f"{prefix}: directory name must use lowercase kebab-case")
+
+        skill_file = skill_dir / "SKILL.md"
+        if not skill_file.is_file():
+            errors.append(f"{prefix}: missing SKILL.md")
+            continue
+        try:
+            text = skill_file.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            errors.append(f"{prefix}/SKILL.md: file must be UTF-8")
+            continue
+
+        metadata = parse_frontmatter(text)
+        declared_name = metadata.get("name", "")
+        description = metadata.get("description", "")
+        if declared_name != skill_name:
+            errors.append(
+                f"{prefix}/SKILL.md: frontmatter name '{declared_name}' must match '{skill_name}'"
+            )
+        if len(description) < 20:
+            errors.append(
+                f"{prefix}/SKILL.md: description must explain capability and trigger (minimum 20 chars)"
+            )
+        if not text[end_of_frontmatter(text):].strip().startswith("#"):
+            errors.append(f"{prefix}/SKILL.md: body must start with a Markdown heading")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (default: inferred from script location)",
+    )
+    args = parser.parse_args()
+    root = args.root.resolve()
+    errors = validate(root)
+    if errors:
+        print("Agent skill validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print(f"Agent skill validation passed: {root / '.agents' / 'skills'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/matrix-api-integration/SKILL.md
+++ b/.agents/skills/matrix-api-integration/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: matrix-api-integration
+description: Integrate Matrix Web with backend APIs. Use for Axios clients, endpoint modules, request and response DTO mapping, authentication, permissions, pagination, error handling, file upload or download, streaming, request cancellation, or frontend-backend debugging.
+metadata:
+  author: micor
+  version: "1.0.0"
+---
+
+# Matrix API Integration
+
+## Objective
+
+Create explicit, maintainable frontend-backend contracts that preserve authentication, business status, error meaning, and financial data precision.
+
+## Required context
+
+Before editing:
+
+1. Read `/AGENTS.md`.
+2. Inspect the existing request abstraction, token handling, interceptors, and feature API modules.
+3. Inspect the relevant backend controller, DTO, enum, and response structure when accessible.
+4. Confirm endpoint path, HTTP method, parameters, body, response, errors, permissions, and idempotency expectations.
+5. Identify whether rapid requests can race or writes can be repeated.
+
+## Source of truth
+
+Use the backend implementation and agreed API contract as the source of truth.
+
+Do not invent:
+
+- Field names.
+- Status values.
+- Pagination shapes.
+- Date formats.
+- Error codes.
+- Permission behavior.
+- Whether a write operation is idempotent.
+
+When the contract is unclear, document the uncertainty and avoid presenting guesses as verified behavior.
+
+## API modules
+
+- Keep endpoint details out of route templates when a feature API module can own them.
+- Group functions by business capability, not by HTTP verb.
+- Use descriptive names such as `postVoucher`, `listVoucherLines`, or `reverseVoucher`.
+- Keep request DTO mapping explicit.
+- Normalize recurring response envelopes in one place.
+- Do not spread endpoint paths and response-unwrapping logic across multiple components.
+
+## Authentication and authorization
+
+- Reuse existing token handling.
+- Never log tokens or include them in user-visible errors.
+- Handle unauthorized and forbidden responses distinctly.
+- Route guards improve UX but do not replace backend authorization.
+- Do not display business actions that the user cannot execute when permission data is available.
+- Remove tokens from URLs after supported token-based entry flows.
+
+## Request parameters
+
+- Normalize empty values consistently.
+- Use backend-supported date and enum formats.
+- Encode arrays, pagination, and sorting according to the established contract.
+- Do not send UI-only state.
+- Preserve zero and false values; do not drop them through truthiness checks.
+- Use multipart requests only for endpoints that require them.
+
+## Response mapping
+
+- Distinguish transport success from business success when the response envelope contains business codes.
+- Map server fields into view models when presentation needs differ.
+- Preserve server-generated identifiers, statuses, timestamps, and trace data.
+- Do not convert precise decimal strings into floating-point numbers when precision matters.
+- Treat absent optional fields separately from explicit zero or empty values.
+
+## Errors
+
+Handle intentionally:
+
+- Network unavailable or timeout.
+- Unauthorized.
+- Forbidden.
+- Validation failure.
+- Not found.
+- Status or version conflict.
+- Rate limit or repeated operation.
+- Server failure.
+
+Error messages should:
+
+- Be concise and actionable.
+- Preserve useful backend business messages.
+- Avoid stack traces, internal URLs, SQL details, or sensitive payloads.
+- Avoid falsely claiming that a write failed when its outcome is uncertain after a timeout.
+
+For uncertain write outcomes, refresh or reconcile the record before retrying automatically.
+
+## Loading and duplicate writes
+
+- Track pending state around writes.
+- Disable repeated controls or deduplicate the action.
+- Do not automatically retry non-idempotent writes unless the backend contract supports it.
+- For long operations, show progress or a clear pending state.
+- Separate initial load from background refresh when useful.
+
+## Request races
+
+For searches, autocomplete, or rapid navigation:
+
+- Abort the previous request, or
+- Track the latest request identity and ignore stale responses.
+
+For writes:
+
+- Preserve operation ordering when later operations depend on earlier ones.
+- Never let a stale response overwrite a newly confirmed state.
+
+## Pagination and sorting
+
+- Keep the visual state aligned with the exact request.
+- Use only supported backend sort fields.
+- Confirm whether page indexing starts at zero or one.
+- Do not infer total count from page length when the API provides an explicit total.
+- Reset to page one after meaningful filter changes unless the contract says otherwise.
+
+## Files and exports
+
+Uploads:
+
+- Validate basic file type and size for user feedback, while relying on backend validation for authority.
+- Use multipart encoding correctly.
+- Surface parsing errors without losing the user's context.
+
+Downloads and exports:
+
+- Use the applied filter scope.
+- Handle binary responses and filenames safely.
+- Avoid exposing authorization tokens in generated URLs.
+- Prevent duplicate export requests.
+
+## Streaming and AI responses
+
+- Define connection close, timeout, cancellation, parse-error, and partial-response behavior.
+- Do not treat incomplete streamed content as a completed authoritative result.
+- Preserve trace IDs and citations when returned.
+- Never render model output as trusted HTML without sanitization.
+
+## Integration debugging workflow
+
+1. Reproduce the request from the frontend.
+2. Record method, path, parameters, body shape, and response status without secrets.
+3. Compare with the backend controller and DTO.
+4. Check gateway path rewriting and context paths.
+5. Check token and permission behavior.
+6. Check date, number, enum, and pagination serialization.
+7. Check request races and stale state.
+8. Fix the owning layer rather than adding repeated component workarounds.
+
+## Verification
+
+At minimum:
+
+```bash
+npm run build
+```
+
+Also verify the relevant success, validation, unauthorized/forbidden, and failure paths when the environment permits.
+
+## Completion report
+
+State:
+
+- Endpoints and DTO mappings changed.
+- Authentication, permission, and error behavior.
+- Race and duplicate-write protections.
+- Build and integration checks performed.
+- Any contract uncertainty or backend dependency.

--- a/.agents/skills/matrix-api-integration/assets/api-contract-checklist.md
+++ b/.agents/skills/matrix-api-integration/assets/api-contract-checklist.md
@@ -1,0 +1,63 @@
+# Matrix Frontend API Contract Checklist
+
+Complete this checklist before integrating or changing a backend endpoint.
+
+## Endpoint identity
+
+- HTTP method:
+- Path:
+- Owning backend module:
+- Controller method:
+- Required permission or role:
+
+## Request
+
+- Path parameters and types:
+- Query parameters and defaults:
+- Request body DTO:
+- Date/time format and timezone:
+- Monetary fields transported as number or exact string:
+- Enum values and unknown-value behavior:
+- Idempotency key or duplicate-submit protection:
+
+## Response
+
+- `ApiResponse<T>` envelope confirmed:
+- Success code and message semantics:
+- Data DTO shape:
+- Nullable and optional fields:
+- Pagination fields (`records/items`, `total`, `page`, `size`):
+- Sorting contract:
+- Large identifier precision risk:
+
+## Error behavior
+
+- Validation error status and message:
+- Authentication and authorization failures:
+- Not-found behavior:
+- State-conflict behavior, such as already posted or period closed:
+- Retryable server or network failures:
+- Partial-success behavior for batch APIs:
+
+## UI state mapping
+
+| Backend condition | UI behavior |
+|---|---|
+| Request pending | Loading indicator; conflicting actions disabled |
+| Success with data | Render authoritative backend data |
+| Success with empty data | Explicit empty state; no fabricated records |
+| Validation failure | Field-level errors where possible |
+| Permission denied | Disable or hide action and display meaningful feedback |
+| State conflict | Refresh current record and explain the new state |
+| Network/server failure | Preserve user input and provide retry behavior |
+| Stale response | Ignore using request sequence or cancellation |
+
+## Verification
+
+- [ ] Compared frontend assumptions with the actual Java controller and DTOs.
+- [ ] Tested loading, success, empty, error, and permission states.
+- [ ] Tested rapid filter changes or duplicate clicks.
+- [ ] Confirmed amount/date/ID precision.
+- [ ] Confirmed no sensitive request or response data is logged.
+- [ ] Ran `npm run build`.
+- [ ] Recorded any backend dependency or unresolved contract risk.

--- a/.agents/skills/matrix-api-integration/references/async-state.md
+++ b/.agents/skills/matrix-api-integration/references/async-state.md
@@ -1,0 +1,50 @@
+# Async State and Request-Race Reference
+
+Use this reference when a page can issue repeated searches, change routes quickly, stream responses, or perform non-idempotent writes.
+
+## Read requests
+
+For replaceable reads such as search and autocomplete:
+
+- Abort the previous request when the request layer supports it, or
+- Assign a monotonically increasing request ID and ignore responses that are no longer current.
+
+Do not allow an older response to replace newer user intent.
+
+## Route changes
+
+When a route changes while a request is pending:
+
+- Cancel or ignore the obsolete result.
+- Avoid updating state for a component that is no longer active.
+- Do not show errors from a request the user intentionally abandoned.
+
+## Write requests
+
+For create, submit, audit, post, reverse, delete, and similar operations:
+
+- Guard the handler against repeated execution.
+- Bind pending state to the initiating control.
+- Do not automatically retry unless the operation is confirmed idempotent.
+- If a timeout leaves the outcome uncertain, refresh or reconcile authoritative state before another attempt.
+
+## Loading states
+
+Distinguish when useful:
+
+- `loading`: initial content is unavailable.
+- `refreshing`: existing content remains usable while updating.
+- `submitting`: a write is pending.
+- `exporting`: a file-generation request is pending.
+
+Avoid one global boolean when independent operations can occur safely in parallel.
+
+## Error ownership
+
+Handle errors at the layer that can provide the best recovery:
+
+- Request layer: authentication expiry and common transport normalization.
+- Feature API layer: endpoint-specific mapping.
+- Page or component: user action, input preservation, retry, and navigation.
+
+Avoid displaying the same error multiple times from interceptors and components.

--- a/.agents/skills/matrix-form-page/SKILL.md
+++ b/.agents/skills/matrix-form-page/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: matrix-form-page
+description: Build or modify Matrix Web create, edit, view, approval, audit, or workflow forms. Use for validation, defaults, field dependencies, save, submit, unsaved changes, dynamic forms, or financial document editing.
+metadata:
+  author: micor
+  version: "1.0.0"
+---
+
+# Matrix Form Page Development
+
+## Objective
+
+Build reliable enterprise forms that preserve user input, respect backend workflow states, and prevent ambiguous or duplicate financial mutations.
+
+## Required context
+
+Before editing:
+
+1. Read `/AGENTS.md`.
+2. Read `matrix-ui` when changing layout or interaction.
+3. Inspect a neighboring form using the same component library.
+4. Confirm request and response DTOs, backend validation, status transitions, and permissions.
+5. Identify form mode: create, edit, view, submit, audit, reject, post, reverse, or another explicit workflow action.
+
+## Form model
+
+Define intentionally:
+
+- Initial values.
+- Loaded server values.
+- Editable values.
+- Derived display values.
+- Field validation state.
+- Dirty state.
+- Pending request state.
+- Form mode and business status.
+
+Do not let `undefined`, empty string, `null`, zero, and missing fields become interchangeable accidentally.
+
+## Mode and status
+
+- Keep route mode and business status explicit.
+- Do not expose editing for backend-immutable states.
+- Read-only fields should be clearly readable, not merely disabled without context.
+- Status transitions must use dedicated actions when the backend models them separately.
+- Do not treat “save draft,” “submit,” “audit,” “post,” and “reverse” as equivalent save operations.
+
+## Validation
+
+- Match backend constraints and terminology.
+- Use field-level validation for local input errors.
+- Use form-level validation for cross-field rules.
+- Do not reimplement complex financial authority solely in the browser.
+- Keep validation messages specific and actionable.
+- Preserve server validation messages where safe and useful.
+- Revalidate dependent fields when controlling fields change.
+
+Financial examples requiring explicit handling include:
+
+- Debit-credit exclusivity and balance.
+- Accounting period availability.
+- Currency, exchange rate, and original amount relationships.
+- Required organization, ledger, account, customer, or supplier scope.
+- Document status restrictions.
+
+## Data loading
+
+For edit or view mode:
+
+1. Load the record and required reference data deliberately.
+2. Do not render default values as real server values during loading.
+3. Handle not found, forbidden, stale, and failed requests distinctly.
+4. Avoid overwriting user edits if background reference data refreshes.
+5. Normalize backend data before binding it to controls.
+
+## Submission
+
+- Validate before sending.
+- Prevent duplicate submission.
+- Do not show success until the server confirms it.
+- Keep the button in a pending state during the request.
+- Preserve user input after recoverable errors.
+- Map the form model to a request DTO explicitly; do not send internal UI-only fields.
+- Refresh or navigate only after successful completion.
+- Avoid losing server-generated IDs, numbers, statuses, or timestamps after save.
+
+## Unsaved changes
+
+When leaving would lose meaningful user input:
+
+- Track dirty state.
+- Confirm route navigation, dialog close, or mode change.
+- Do not warn when only server initialization changed the model.
+- Clear dirty state after a confirmed successful save or reset.
+
+## Dynamic fields
+
+- Use stable field identities.
+- Remove obsolete validation and payload values when a conditional section becomes inactive, unless the backend explicitly needs them.
+- Avoid deeply nested watchers that synchronize duplicate state.
+- Prefer computed values and explicit event handlers.
+- For line-entry forms, preserve row identity and validate each line with a meaningful row number.
+
+## Financial line-entry forms
+
+- Use stable row IDs independent of array position.
+- Right-align numeric inputs.
+- Define decimal precision and rounding presentation.
+- Never use JavaScript floating-point totals as the authoritative accounting result.
+- Display client-side totals only as assistance; rely on backend validation for final correctness.
+- Prevent a row from having incompatible debit and credit values.
+- Clearly identify invalid lines.
+- Preserve lines after recoverable submission failures.
+
+## Errors and conflicts
+
+Handle at least:
+
+- Local validation errors.
+- Backend validation errors.
+- Unauthorized or forbidden access.
+- Record not found.
+- Version or status conflict.
+- Network failure.
+- Server failure.
+
+For status conflicts, refresh the authoritative record before allowing another mutation.
+
+## Implementation workflow
+
+1. Define modes, statuses, and permissions.
+2. Confirm DTOs and backend validation.
+3. Define initialization, normalization, validation, and payload mapping.
+4. Implement loading and error states.
+5. Implement submit protection and unsaved-change handling.
+6. Verify create, edit, view, failure, and conflict paths.
+7. Run `npm run build`.
+8. Review with `matrix-frontend-review`.
+
+## Completion report
+
+State:
+
+- Form modes and fields changed.
+- Validation and payload behavior.
+- Status and permission restrictions.
+- Duplicate-submit and unsaved-change behavior.
+- Build result.
+- Remaining backend-contract or workflow risks.

--- a/.agents/skills/matrix-form-page/assets/element-plus-form-page-template.vue
+++ b/.agents/skills/matrix-form-page/assets/element-plus-form-page-template.vue
@@ -18,7 +18,6 @@
         :rules="rules"
         label-width="120px"
         :disabled="readOnly || saving"
-        @change="markDirty"
       >
         <el-form-item label="编号" prop="number">
           <el-input v-model.trim="form.number" maxlength="64" show-word-limit />
@@ -43,7 +42,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
 // TODO(matrix): replace with the owning feature API module.
 import { createRecord, getRecord, updateRecord } from '@/api/replace-with-feature-api'
@@ -74,13 +73,14 @@ function snapshot() {
   return JSON.stringify(form)
 }
 
-function markDirty() {
+watch(form, () => {
   dirty.value = snapshot() !== initialSnapshot
-}
+}, { deep: true })
 
 async function loadDetail() {
   if (!recordId.value) {
     initialSnapshot = snapshot()
+    dirty.value = false
     return
   }
   loading.value = true

--- a/.agents/skills/matrix-form-page/assets/element-plus-form-page-template.vue
+++ b/.agents/skills/matrix-form-page/assets/element-plus-form-page-template.vue
@@ -1,0 +1,161 @@
+<!-- Copy into src/views and replace every TODO(matrix) placeholder. -->
+<template>
+  <section class="page-shell">
+    <header class="page-header">
+      <div>
+        <h1>{{ pageTitle }}</h1>
+        <p>TODO(matrix): 说明业务对象、组织、账簿或期间范围。</p>
+      </div>
+      <el-button @click="goBack">返回</el-button>
+    </header>
+
+    <el-alert v-if="errorMessage" :title="errorMessage" type="error" show-icon closable class="state-block" />
+
+    <el-card v-loading="loading" shadow="never">
+      <el-form
+        ref="formRef"
+        :model="form"
+        :rules="rules"
+        label-width="120px"
+        :disabled="readOnly || saving"
+        @change="markDirty"
+      >
+        <el-form-item label="编号" prop="number">
+          <el-input v-model.trim="form.number" maxlength="64" show-word-limit />
+        </el-form-item>
+        <el-form-item label="名称" prop="name">
+          <el-input v-model.trim="form.name" maxlength="120" show-word-limit />
+        </el-form-item>
+        <el-form-item label="金额" prop="amount">
+          <el-input-number v-model="form.amount" :precision="2" :min="0" controls-position="right" />
+        </el-form-item>
+        <el-form-item label="说明" prop="remark">
+          <el-input v-model="form.remark" type="textarea" :rows="4" maxlength="500" show-word-limit />
+        </el-form-item>
+
+        <el-form-item v-if="!readOnly">
+          <el-button type="primary" :loading="saving" @click="handleSubmit">保存</el-button>
+          <el-button :disabled="saving" @click="handleReset">重置</el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+  </section>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref } from 'vue'
+import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
+// TODO(matrix): replace with the owning feature API module.
+import { createRecord, getRecord, updateRecord } from '@/api/replace-with-feature-api'
+
+const route = useRoute()
+const router = useRouter()
+const formRef = ref()
+const loading = ref(false)
+const saving = ref(false)
+const dirty = ref(false)
+const errorMessage = ref('')
+let initialSnapshot = ''
+
+const recordId = computed(() => route.params.id || null)
+const mode = computed(() => String(route.meta?.mode || (recordId.value ? 'edit' : 'create')))
+const readOnly = computed(() => mode.value === 'view')
+const pageTitle = computed(() => ({ create: '新增 TODO(matrix)', edit: '编辑 TODO(matrix)', view: '查看 TODO(matrix)' })[mode.value] || 'TODO(matrix)')
+
+const emptyForm = () => ({ number: '', name: '', amount: null, remark: '' })
+const form = reactive(emptyForm())
+const rules = {
+  number: [{ required: true, message: '请输入编号', trigger: 'blur' }],
+  name: [{ required: true, message: '请输入名称', trigger: 'blur' }],
+  amount: [{ required: true, message: '请输入金额', trigger: 'change' }],
+}
+
+function snapshot() {
+  return JSON.stringify(form)
+}
+
+function markDirty() {
+  dirty.value = snapshot() !== initialSnapshot
+}
+
+async function loadDetail() {
+  if (!recordId.value) {
+    initialSnapshot = snapshot()
+    return
+  }
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const response = await getRecord(recordId.value)
+    // TODO(matrix): normalize using the actual ApiResponse contract.
+    const data = response?.data?.data ?? response?.data ?? {}
+    Object.assign(form, emptyForm(), data)
+    initialSnapshot = snapshot()
+    dirty.value = false
+  } catch (error) {
+    errorMessage.value = error?.response?.data?.message || error?.message || '数据加载失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleSubmit() {
+  if (saving.value || readOnly.value) return
+  errorMessage.value = ''
+  const valid = await formRef.value?.validate().catch(() => false)
+  if (!valid) return
+
+  saving.value = true
+  try {
+    const payload = {
+      number: form.number,
+      name: form.name,
+      // Keep decimal values as strings when the backend contract requires exact transport precision.
+      amount: form.amount === null ? null : String(form.amount),
+      remark: form.remark || null,
+    }
+    if (recordId.value) {
+      await updateRecord(recordId.value, payload)
+    } else {
+      await createRecord(payload)
+    }
+    initialSnapshot = snapshot()
+    dirty.value = false
+    goBack()
+  } catch (error) {
+    errorMessage.value = error?.response?.data?.message || error?.message || '保存失败，请检查数据状态后重试'
+  } finally {
+    saving.value = false
+  }
+}
+
+function handleReset() {
+  if (recordId.value) {
+    loadDetail()
+  } else {
+    Object.assign(form, emptyForm())
+    initialSnapshot = snapshot()
+    dirty.value = false
+    formRef.value?.clearValidate()
+  }
+}
+
+function goBack() {
+  router.back()
+}
+
+onBeforeRouteLeave(() => {
+  if (!dirty.value || saving.value || readOnly.value) return true
+  return window.confirm('当前修改尚未保存，确定离开吗？')
+})
+
+onMounted(loadDetail)
+</script>
+
+<style scoped>
+.page-shell { padding: 20px; }
+.page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; margin-bottom: 16px; }
+.page-header h1 { margin: 0 0 6px; font-size: 22px; }
+.page-header p { margin: 0; color: var(--el-text-color-secondary); }
+.state-block { margin-bottom: 16px; }
+</style>

--- a/.agents/skills/matrix-form-page/assets/vuetify-form-page-template.vue
+++ b/.agents/skills/matrix-form-page/assets/vuetify-form-page-template.vue
@@ -1,0 +1,157 @@
+<!-- Copy into src/views and replace every TODO(matrix) placeholder. -->
+<template>
+  <v-container fluid class="page-shell">
+    <div class="page-header">
+      <div>
+        <h1 class="text-h5 font-weight-bold">{{ pageTitle }}</h1>
+        <p class="text-body-2 text-medium-emphasis">TODO(matrix): 说明业务对象、组织、账簿或期间范围。</p>
+      </div>
+      <v-btn variant="outlined" @click="goBack">返回</v-btn>
+    </div>
+
+    <v-alert v-if="errorMessage" type="error" variant="tonal" closable class="mb-4">
+      {{ errorMessage }}
+    </v-alert>
+
+    <v-card variant="outlined" :loading="loading">
+      <v-card-text>
+        <v-form ref="formRef" :disabled="readOnly || saving" @submit.prevent="handleSubmit">
+          <v-row>
+            <v-col cols="12" md="6">
+              <v-text-field v-model.trim="form.number" label="编号" :rules="requiredRules" maxlength="64" counter />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-text-field v-model.trim="form.name" label="名称" :rules="requiredRules" maxlength="120" counter />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-number-input v-model="form.amount" label="金额" :min="0" :precision="2" :rules="amountRules" />
+            </v-col>
+            <v-col cols="12">
+              <v-textarea v-model="form.remark" label="说明" rows="4" maxlength="500" counter />
+            </v-col>
+          </v-row>
+
+          <div v-if="!readOnly" class="d-flex ga-2 justify-end">
+            <v-btn variant="outlined" :disabled="saving" @click="handleReset">重置</v-btn>
+            <v-btn color="primary" type="submit" :loading="saving">保存</v-btn>
+          </div>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
+// TODO(matrix): replace with the owning feature API module.
+import { createRecord, getRecord, updateRecord } from '@/api/replace-with-feature-api'
+
+const route = useRoute()
+const router = useRouter()
+const formRef = ref()
+const loading = ref(false)
+const saving = ref(false)
+const dirty = ref(false)
+const errorMessage = ref('')
+let initialSnapshot = ''
+
+const recordId = computed(() => route.params.id || null)
+const mode = computed(() => String(route.meta?.mode || (recordId.value ? 'edit' : 'create')))
+const readOnly = computed(() => mode.value === 'view')
+const pageTitle = computed(() => ({ create: '新增 TODO(matrix)', edit: '编辑 TODO(matrix)', view: '查看 TODO(matrix)' })[mode.value] || 'TODO(matrix)')
+
+const emptyForm = () => ({ number: '', name: '', amount: null, remark: '' })
+const form = reactive(emptyForm())
+const requiredRules = [(value) => Boolean(String(value ?? '').trim()) || '该字段不能为空']
+const amountRules = [(value) => value !== null && value !== undefined || '请输入金额']
+
+function snapshot() {
+  return JSON.stringify(form)
+}
+
+watch(form, () => {
+  dirty.value = snapshot() !== initialSnapshot
+}, { deep: true })
+
+async function loadDetail() {
+  if (!recordId.value) {
+    initialSnapshot = snapshot()
+    dirty.value = false
+    return
+  }
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const response = await getRecord(recordId.value)
+    // TODO(matrix): normalize using the actual ApiResponse contract.
+    const data = response?.data?.data ?? response?.data ?? {}
+    Object.assign(form, emptyForm(), data)
+    initialSnapshot = snapshot()
+    dirty.value = false
+  } catch (error) {
+    errorMessage.value = error?.response?.data?.message || error?.message || '数据加载失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleSubmit() {
+  if (saving.value || readOnly.value) return
+  errorMessage.value = ''
+  const result = await formRef.value?.validate()
+  if (!result?.valid) return
+
+  saving.value = true
+  try {
+    const payload = {
+      number: form.number,
+      name: form.name,
+      amount: form.amount === null ? null : String(form.amount),
+      remark: form.remark || null,
+    }
+    if (recordId.value) {
+      await updateRecord(recordId.value, payload)
+    } else {
+      await createRecord(payload)
+    }
+    initialSnapshot = snapshot()
+    dirty.value = false
+    goBack()
+  } catch (error) {
+    errorMessage.value = error?.response?.data?.message || error?.message || '保存失败，请检查数据状态后重试'
+  } finally {
+    saving.value = false
+  }
+}
+
+function handleReset() {
+  if (recordId.value) {
+    loadDetail()
+  } else {
+    Object.assign(form, emptyForm())
+    initialSnapshot = snapshot()
+    dirty.value = false
+    formRef.value?.resetValidation()
+  }
+}
+
+function goBack() {
+  router.back()
+}
+
+onBeforeRouteLeave(() => {
+  if (!dirty.value || saving.value || readOnly.value) return true
+  return window.confirm('当前修改尚未保存，确定离开吗？')
+})
+
+onMounted(loadDetail)
+</script>
+
+<style scoped>
+.page-shell { padding: 20px; }
+.page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; margin-bottom: 16px; }
+@media (max-width: 960px) {
+  .page-header { flex-direction: column; }
+}
+</style>

--- a/.agents/skills/matrix-form-page/assets/vuetify-form-page-template.vue
+++ b/.agents/skills/matrix-form-page/assets/vuetify-form-page-template.vue
@@ -24,7 +24,15 @@
               <v-text-field v-model.trim="form.name" label="名称" :rules="requiredRules" maxlength="120" counter />
             </v-col>
             <v-col cols="12" md="6">
-              <v-number-input v-model="form.amount" label="金额" :min="0" :precision="2" :rules="amountRules" />
+              <v-text-field
+                v-model="form.amount"
+                label="金额"
+                type="number"
+                inputmode="decimal"
+                min="0"
+                step="0.01"
+                :rules="amountRules"
+              />
             </v-col>
             <v-col cols="12">
               <v-textarea v-model="form.remark" label="说明" rows="4" maxlength="500" counter />
@@ -64,7 +72,10 @@ const pageTitle = computed(() => ({ create: '新增 TODO(matrix)', edit: '编辑
 const emptyForm = () => ({ number: '', name: '', amount: null, remark: '' })
 const form = reactive(emptyForm())
 const requiredRules = [(value) => Boolean(String(value ?? '').trim()) || '该字段不能为空']
-const amountRules = [(value) => value !== null && value !== undefined || '请输入金额']
+const amountRules = [
+  (value) => value !== null && value !== undefined && value !== '' || '请输入金额',
+  (value) => Number(value) >= 0 || '金额不能小于 0',
+]
 
 function snapshot() {
   return JSON.stringify(form)
@@ -107,7 +118,7 @@ async function handleSubmit() {
     const payload = {
       number: form.number,
       name: form.name,
-      amount: form.amount === null ? null : String(form.amount),
+      amount: form.amount === null || form.amount === '' ? null : String(form.amount),
       remark: form.remark || null,
     }
     if (recordId.value) {

--- a/.agents/skills/matrix-frontend-review/SKILL.md
+++ b/.agents/skills/matrix-frontend-review/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: matrix-frontend-review
+description: Review Matrix Web changes for correctness and release risk. Use for pull request review, regression analysis, pre-merge validation, accessibility review, API-contract review, financial UI review, performance checks, or AI-generated frontend code inspection.
+metadata:
+  author: micor
+  version: "1.0.0"
+---
+
+# Matrix Frontend Review
+
+## Objective
+
+Identify concrete correctness, workflow, integration, accessibility, security, and maintainability risks before frontend changes are merged or released.
+
+## Review posture
+
+Prioritize defects and user impact over stylistic preference.
+
+Do not report hypothetical concerns without connecting them to a specific code path, state, contract, or user flow.
+
+## Required context
+
+Before reviewing:
+
+1. Read `/AGENTS.md`.
+2. Read applicable implementation skills.
+3. Understand the user flow and backend contract.
+4. Inspect the full changed component or module, not only isolated diff lines when context matters.
+5. Identify affected routes, permissions, statuses, APIs, and shared components.
+6. Use `assets/review-checklist.md` for a pre-merge pass.
+
+## Severity levels
+
+### Critical
+
+Likely to cause severe financial corruption, credential exposure, broad unauthorized access, irreversible user harm, or a production-blocking failure.
+
+### High
+
+Likely to break a primary workflow, allow an invalid financial action, lose user data, create duplicate writes, expose sensitive data, or present materially wrong financial information.
+
+### Medium
+
+Produces incorrect behavior in realistic conditions, weak error recovery, stale data, accessibility barriers, significant regression risk, or material maintainability problems.
+
+### Low
+
+Localized quality issue with limited user impact. Do not inflate stylistic preferences into defects.
+
+## Review dimensions
+
+### 1. Functional correctness
+
+Check:
+
+- Route and component behavior.
+- Create, edit, view, and workflow modes.
+- Loading, empty, error, permission, and success states.
+- Field defaults and value normalization.
+- Navigation after successful and failed actions.
+- State cleanup when components unmount or routes change.
+
+### 2. Financial correctness
+
+Check:
+
+- Amount, rate, quantity, percentage, debit, and credit presentation.
+- Currency and accounting-period scope.
+- Status-dependent action availability.
+- Disabled editing for immutable records.
+- Destructive-action confirmation.
+- No authoritative financial calculations using JavaScript floating point.
+- No misleading totals created from only the visible page.
+
+### 3. API contract
+
+Check:
+
+- Endpoint, method, parameter, and body shape.
+- Response envelope and DTO mapping.
+- Enum, date, decimal, and pagination serialization.
+- Unauthorized, forbidden, validation, conflict, and server-error handling.
+- Request cancellation or stale-response protection.
+- Duplicate-write prevention.
+- Uncertain write outcomes after timeout.
+
+### 4. State management
+
+Check:
+
+- Derived state is computed rather than duplicated.
+- Props are not mutated.
+- Store usage is justified by cross-route sharing.
+- Watchers do not create loops or hidden synchronization.
+- List and line-entry items use stable keys.
+- Dirty-state logic distinguishes initialization from user edits.
+
+### 5. UI consistency
+
+Check:
+
+- The surrounding component library is reused.
+- Element Plus and Vuetify are not mixed unnecessarily in one page.
+- Similar pages use consistent spacing, hierarchy, actions, and statuses.
+- Long text, large values, and wide tables are handled.
+- Empty and failed states are not blank.
+
+### 6. Accessibility
+
+Check:
+
+- Keyboard access.
+- Accessible labels and names.
+- Visible focus.
+- Modal focus and close behavior.
+- Status is not communicated only through color.
+- Icon-only controls have labels.
+- Errors are associated with the relevant field or action.
+
+### 7. Security and privacy
+
+Check:
+
+- Tokens are not logged or persisted insecurely.
+- Sensitive financial or personal payloads are not exposed in console output or errors.
+- Model-generated content is not rendered as trusted HTML.
+- Permission checks are not assumed solely from hidden buttons.
+- File downloads and URLs do not leak credentials.
+
+### 8. Performance
+
+Check:
+
+- Large datasets use backend pagination.
+- Repeated rendering and watchers are reasonable.
+- Search requests are controlled.
+- Heavy components or dependencies are not added without need.
+- Large reports are not aggregated inefficiently in the browser.
+- Repeated formatters or transformations are not unnecessarily recomputed.
+
+### 9. Maintainability
+
+Check:
+
+- API logic is centralized appropriately.
+- Reusable behavior is extracted without over-abstraction.
+- Component responsibilities remain clear.
+- Naming uses business terminology.
+- Comments explain constraints rather than restating code.
+- Dead branches, mocks, temporary logs, and unused imports are removed.
+
+### 10. Validation evidence
+
+Check whether the change author ran:
+
+```bash
+npm run build
+```
+
+Also look for evidence of:
+
+- Relevant manual flow checks.
+- Error-path checks.
+- Width and long-content checks.
+- Integration verification where available.
+
+Do not treat a passing build as proof that the workflow is correct.
+
+## Finding format
+
+Each actionable finding should include:
+
+- Severity.
+- File and location.
+- Problem.
+- Concrete consequence.
+- Recommended correction.
+
+Example:
+
+```text
+Severity: High
+Location: src/views/.../VoucherForm.vue, submit handler
+Problem: The submit button remains enabled while the request is pending.
+Consequence: A double click can create two non-idempotent write requests.
+Recommendation: Guard the handler and bind the pending state to the action control.
+```
+
+## Review workflow
+
+1. Summarize the intended behavior.
+2. Trace the primary user flow.
+3. Trace failure, permission, and conflict paths.
+4. Compare frontend assumptions with backend contracts.
+5. Review financial display and workflow restrictions.
+6. Review race, duplicate-action, and stale-state risks.
+7. Review accessibility and responsive behavior.
+8. Review build and manual validation evidence.
+9. Report findings ordered by severity.
+10. If no material defects are found, state residual risks and untested areas.
+
+## Completion report
+
+Return:
+
+1. Actionable findings ordered by severity.
+2. Questions only where contract ambiguity materially affects correctness.
+3. Validation gaps.
+4. A concise overall risk assessment.

--- a/.agents/skills/matrix-frontend-review/assets/review-checklist.md
+++ b/.agents/skills/matrix-frontend-review/assets/review-checklist.md
@@ -1,0 +1,112 @@
+# Matrix Web Pre-Merge Review Checklist
+
+Use this checklist for changed behavior, not only changed lines.
+
+## Scope
+
+- [ ] The affected route, page, component, store, API module, and backend dependency are identified.
+- [ ] The intended user flow and business status are understood.
+- [ ] Cross-repository impact on `matrix` has been considered.
+
+## Functional states
+
+- [ ] Initial loading is handled.
+- [ ] Background refresh does not misleadingly blank current data.
+- [ ] Empty state distinguishes no data from no filter matches where relevant.
+- [ ] Request failure is visible and actionable.
+- [ ] Unauthorized and forbidden behavior is intentional.
+- [ ] Not-found and status-conflict behavior is intentional.
+- [ ] Successful writes use the authoritative server response.
+
+## Forms
+
+- [ ] Create, edit, view, and workflow modes are explicit.
+- [ ] Defaults distinguish missing, null, empty, zero, and false values.
+- [ ] Client validation aligns with backend validation.
+- [ ] Server validation messages are handled safely.
+- [ ] Duplicate submission is prevented.
+- [ ] Recoverable failure preserves meaningful input.
+- [ ] Unsaved-change behavior is intentional.
+- [ ] UI-only fields are not sent to the backend.
+
+## Tables and reports
+
+- [ ] Large datasets use backend pagination.
+- [ ] Search resets pagination appropriately.
+- [ ] Sorting matches backend-supported fields.
+- [ ] Stable row identities are used.
+- [ ] Monetary and numeric values are right-aligned and consistently formatted.
+- [ ] Long text and large values do not break the layout.
+- [ ] Summary values use the same scope as detail rows.
+- [ ] Export matches applied filters and permissions.
+- [ ] Batch actions define partial-success behavior.
+
+## Financial workflow
+
+- [ ] Organization, ledger, currency, and period scope are visible where needed.
+- [ ] Debit and credit are explicitly distinguished.
+- [ ] Immutable statuses do not expose edit actions.
+- [ ] High-impact financial actions require confirmation.
+- [ ] JavaScript floating point is not used for authoritative financial totals.
+- [ ] The UI does not claim a financial write succeeded before server confirmation.
+
+## API integration
+
+- [ ] Endpoint method, path, parameters, body, and response match the backend.
+- [ ] Pagination indexing and total count are handled correctly.
+- [ ] Dates, enums, decimals, zero, and false values serialize correctly.
+- [ ] Unauthorized, forbidden, validation, conflict, timeout, and server errors are handled.
+- [ ] Rapid requests cannot allow an older response to replace newer data.
+- [ ] Non-idempotent writes are not retried automatically without support.
+- [ ] Tokens and sensitive payloads are not logged.
+
+## Vue state
+
+- [ ] Props are not mutated.
+- [ ] Derived values use computed state where appropriate.
+- [ ] Watchers are necessary and do not create hidden synchronization loops.
+- [ ] Shared stores are used only for genuinely shared state.
+- [ ] Timers, listeners, subscriptions, and requests are cleaned up where needed.
+- [ ] Lists and dynamic form lines use stable keys.
+
+## UI consistency
+
+- [ ] The surrounding component library is reused.
+- [ ] Element Plus and Vuetify are not mixed unnecessarily in one page.
+- [ ] No third UI framework was introduced.
+- [ ] Primary, secondary, and dangerous actions are visually clear.
+- [ ] Loading, empty, error, and permission states are not blank.
+- [ ] The layout was checked around 1280px and 1920px.
+
+## Accessibility
+
+- [ ] Interactive controls are keyboard reachable.
+- [ ] Inputs and icon-only controls have accessible names.
+- [ ] Visible focus states remain available.
+- [ ] Modal or drawer focus behavior is predictable.
+- [ ] Status and errors are not communicated through color alone.
+- [ ] Error messages identify the problem and next action.
+
+## Security and privacy
+
+- [ ] Tokens, passwords, private data, and sensitive financial payloads are not exposed.
+- [ ] Permission behavior is not enforced only by hidden UI.
+- [ ] Untrusted HTML, including model output, is not rendered unsafely.
+- [ ] Download or redirect URLs do not expose credentials.
+- [ ] Temporary console logging has been removed.
+
+## Performance
+
+- [ ] Full datasets are not loaded for browser-side pagination or aggregation without justification.
+- [ ] Repeated search requests are controlled.
+- [ ] Expensive derived data is not recomputed unnecessarily.
+- [ ] New dependencies are justified.
+- [ ] Wide tables scroll inside a controlled region rather than the whole page.
+
+## Validation
+
+- [ ] `npm run build` passes.
+- [ ] The browser console is clean for the tested flow.
+- [ ] Primary success flow was checked.
+- [ ] At least one relevant failure or validation flow was checked.
+- [ ] Remaining integration or environment gaps are documented.

--- a/.agents/skills/matrix-frontend-review/scripts/scan-sensitive-logs.mjs
+++ b/.agents/skills/matrix-frontend-review/scripts/scan-sensitive-logs.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/** Scan changed frontend files for sensitive logging and risky literals. */
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, statSync } from 'node:fs'
+import { extname, isAbsolute, join, relative, resolve } from 'node:path'
+
+const TEXT_EXTENSIONS = new Set(['.vue', '.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx', '.json', '.env', '.scss', '.css', '.html'])
+const SKIP_SEGMENTS = new Set(['.git', 'node_modules', 'dist', 'coverage'])
+const rootArgIndex = process.argv.indexOf('--root')
+const root = resolve(rootArgIndex >= 0 ? process.argv[rootArgIndex + 1] : process.cwd())
+const strict = process.argv.includes('--strict')
+const explicit = process.argv.slice(2).filter((value, index, all) => {
+  if (value === '--strict' || value === '--root') return false
+  if (index > 0 && all[index - 1] === '--root') return false
+  return true
+})
+
+function gitNames(args) {
+  try {
+    return execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+function selectedFiles() {
+  const names = explicit.length
+    ? explicit
+    : [
+        ...gitNames(['diff', '--name-only', '--diff-filter=ACMR', 'HEAD']),
+        ...gitNames(['ls-files', '--others', '--exclude-standard']),
+      ]
+  const unique = new Set()
+  for (const name of names) {
+    const file = isAbsolute(name) ? name : join(root, name)
+    if (file.includes('\0')) continue
+    let stat
+    try {
+      stat = statSync(file)
+    } catch {
+      continue
+    }
+    if (!stat.isFile() || stat.size > 2_000_000) continue
+    const parts = relative(root, file).split(/[\\/]/)
+    if (parts.some((part) => SKIP_SEGMENTS.has(part))) continue
+    const extension = extname(file).toLowerCase()
+    if (!TEXT_EXTENSIONS.has(extension) && !file.endsWith('.env')) continue
+    unique.add(resolve(file))
+  }
+  return [...unique].sort()
+}
+
+function add(findings, severity, file, line, code, message) {
+  findings.push({ severity, file, line, code, message })
+}
+
+function scan(file) {
+  let text
+  try {
+    text = readFileSync(file, 'utf8')
+  } catch {
+    return []
+  }
+  const findings = []
+  const lines = text.split(/\r?\n/)
+  lines.forEach((line, index) => {
+    const lineNo = index + 1
+    if (/console\.(?:log|debug|info)\s*\(/.test(line)) {
+      if (/(token|authorization|password|passwd|secret|cookie|credential|api[_-]?key)/i.test(line)) {
+        add(findings, 'ERROR', file, lineNo, 'WEBSEC001', 'sensitive value may be written to the browser console')
+      } else {
+        add(findings, 'WARN', file, lineNo, 'WEBSEC002', 'remove console logging from production paths or use the project logger')
+      }
+    }
+    if (/Bearer\s+[A-Za-z0-9._-]{12,}/.test(line)) {
+      add(findings, 'ERROR', file, lineNo, 'WEBSEC003', 'hard-coded bearer credential detected')
+    }
+    if (/-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/.test(line)) {
+      add(findings, 'ERROR', file, lineNo, 'WEBSEC004', 'private key material detected')
+    }
+    if (/\bv-html\s*=/.test(line)) {
+      add(findings, 'WARN', file, lineNo, 'WEBSEC005', 'v-html requires explicit trusted-content sanitization review')
+    }
+    if (/target=["']_blank["']/.test(line) && !/rel=["'][^"']*(?:noopener|noreferrer)/.test(line)) {
+      add(findings, 'WARN', file, lineNo, 'WEBSEC006', 'target=_blank should include rel=noopener or noreferrer')
+    }
+    if (/https?:\/\/\d{1,3}(?:\.\d{1,3}){3}/.test(line) && !/(127\.0\.0\.1|0\.0\.0\.0)/.test(line)) {
+      add(findings, 'WARN', file, lineNo, 'WEBSEC007', 'public service address should normally come from environment configuration')
+    }
+  })
+  return findings
+}
+
+const files = selectedFiles()
+if (files.length === 0) {
+  console.log('No frontend files selected.')
+  process.exit(0)
+}
+
+const findings = files.flatMap(scan)
+for (const finding of findings) {
+  console.log(`[${finding.severity}] ${relative(root, finding.file)}:${finding.line} ${finding.code} ${finding.message}`)
+}
+const errors = findings.filter((item) => item.severity === 'ERROR').length
+const warnings = findings.filter((item) => item.severity === 'WARN').length
+console.log(`Scanned ${files.length} file(s): ${errors} error(s), ${warnings} warning(s).`)
+process.exit(errors > 0 || (strict && warnings > 0) ? 1 : 0)

--- a/.agents/skills/matrix-table-page/SKILL.md
+++ b/.agents/skills/matrix-table-page/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: matrix-table-page
+description: Build or modify Matrix Web data-list and report pages. Use for search forms, filters, tables, pagination, sorting, row actions, batch actions, summaries, exports, large datasets, or financial reports.
+metadata:
+  author: micor
+  version: "1.0.0"
+---
+
+# Matrix Table Page Development
+
+## Objective
+
+Create predictable, scalable list and report pages that preserve business context and remain usable with large enterprise datasets.
+
+## Required context
+
+Before editing:
+
+1. Read `/AGENTS.md`.
+2. Read `matrix-ui` when layout or interaction changes.
+3. Inspect a neighboring table page using the same component library.
+4. Confirm backend pagination, filtering, sorting, summary, and export contracts.
+5. Identify organization, ledger, currency, period, and permission scope.
+
+## Page model
+
+A table page should explicitly model:
+
+- `filters`: user-entered search conditions.
+- `appliedFilters`: conditions used for the current request when separation is useful.
+- `rows`: current page data.
+- `page`, `size`, and total count.
+- `sort`: backend-supported sort definition.
+- `loading`: initial or blocking load.
+- `refreshing`: optional non-blocking refresh.
+- `error`: recoverable request failure.
+- `selection`: selected row identities when batch actions exist.
+
+Avoid scattering these states across unrelated refs without a clear reason.
+
+## Search behavior
+
+- Define defaults deliberately.
+- Search should reset to the first page unless the current contract says otherwise.
+- Reset should restore documented defaults, not arbitrary empty values.
+- Avoid sending empty filters in inconsistent forms such as `""`, `null`, and `undefined`.
+- Debounce only fields that benefit from live search; enterprise filter forms usually use an explicit search action.
+- Preserve filter state when navigating to details and returning where practical.
+
+## Pagination and sorting
+
+- Use backend pagination for potentially large datasets.
+- Never fetch an entire financial dataset simply to paginate in the browser.
+- Keep page size within supported backend limits.
+- Reset to a valid page when filters reduce the result count.
+- Send only backend-supported sort fields.
+- Keep visual sort state synchronized with the request.
+- Use stable row identifiers.
+
+## Table columns
+
+For every column define:
+
+- Business meaning.
+- Source field.
+- Formatting.
+- Alignment.
+- Empty-value behavior.
+- Width or overflow strategy.
+- Sorting support.
+- Permission or sensitivity concerns.
+
+Financial columns:
+
+- Right-align amounts, rates, quantities, and percentages.
+- Preserve expected precision.
+- Show currency when not implied by page scope.
+- Keep debit and credit labels explicit.
+- Do not calculate authoritative totals with JavaScript floating point.
+
+## Row and batch actions
+
+- Display only actions allowed by the current permission and business status.
+- Do not infer editability from frontend state alone when backend rules exist.
+- Require confirmation for destructive or high-impact operations.
+- Disable repeated action while pending.
+- Batch actions must define partial-success behavior.
+- After mutations, refresh the smallest necessary scope and preserve user context.
+
+## Loading, empty, and errors
+
+Initial loading:
+
+- Use the component library's table or skeleton state.
+
+Background refresh:
+
+- Avoid blanking an already usable page unless necessary.
+
+Empty result:
+
+- Distinguish “no records exist” from “filters matched nothing.”
+
+Error:
+
+- Show a concise message and retry option where useful.
+- Preserve filters, page intent, and selection when safe.
+- Never leave stale data appearing current without an error indicator.
+
+## Reports and summaries
+
+- Clearly show report scope.
+- Do not silently combine currencies, organizations, ledgers, or periods.
+- Ensure summary values use the same filters as the detail rows.
+- Prefer server-calculated authoritative financial totals.
+- Label estimated, partial, or delayed data explicitly.
+
+## Export
+
+- Export must use the currently applied scope and filters.
+- Do not imply that only the visible page will export unless that is the intended behavior.
+- Prevent repeated export requests.
+- Handle long-running export generation clearly.
+- Do not include hidden sensitive fields merely because they exist in the response.
+
+## Request-race protection
+
+Rapid searches or route changes can return responses out of order.
+
+Use one of these patterns when relevant:
+
+- Abort the previous request.
+- Track request identity and ignore stale responses.
+- Serialize writes when order matters.
+
+Never allow an older response to replace newer search results.
+
+## Implementation workflow
+
+1. Confirm query and response contracts.
+2. Define table state and scope.
+3. Define filters, columns, formatting, actions, and permissions.
+4. Implement request-race and duplicate-action protection.
+5. Handle loading, empty, error, and partial-success states.
+6. Verify large values, long text, narrow width, and wide tables.
+7. Run `npm run build`.
+8. Review with `matrix-frontend-review`.
+
+## Completion report
+
+State:
+
+- Filters, columns, actions, and report scope changed.
+- Pagination and sorting behavior.
+- Mutation and race protections.
+- Build result.
+- Remaining API or performance risks.

--- a/.agents/skills/matrix-table-page/assets/element-plus-table-page-template.vue
+++ b/.agents/skills/matrix-table-page/assets/element-plus-table-page-template.vue
@@ -1,0 +1,169 @@
+<!-- Copy into src/views and replace every TODO(matrix) placeholder. -->
+<template>
+  <section class="page-shell">
+    <header class="page-header">
+      <div>
+        <h1>TODO(matrix): 页面标题</h1>
+        <p>TODO(matrix): 说明组织、账簿、期间或业务范围。</p>
+      </div>
+      <el-button type="primary" @click="handleCreate">新增</el-button>
+    </header>
+
+    <el-card shadow="never" class="filter-card">
+      <el-form :model="filters" inline @submit.prevent="handleSearch">
+        <el-form-item label="关键词">
+          <el-input v-model.trim="filters.keyword" clearable placeholder="编号或名称" @keyup.enter="handleSearch" />
+        </el-form-item>
+        <el-form-item label="状态">
+          <el-select v-model="filters.status" clearable placeholder="全部状态" style="width: 160px">
+            <el-option label="草稿" value="DRAFT" />
+            <el-option label="已提交" value="SUBMITTED" />
+          </el-select>
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" :loading="loading" @click="handleSearch">查询</el-button>
+          <el-button :disabled="loading" @click="handleReset">重置</el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+
+    <el-alert v-if="errorMessage" :title="errorMessage" type="error" show-icon closable class="state-block" />
+
+    <el-card shadow="never">
+      <el-table
+        v-loading="loading"
+        :data="rows"
+        row-key="id"
+        border
+        @sort-change="handleSortChange"
+      >
+        <el-table-column prop="number" label="编号" min-width="150" show-overflow-tooltip />
+        <el-table-column prop="name" label="名称" min-width="200" show-overflow-tooltip />
+        <el-table-column prop="amount" label="金额" min-width="140" align="right">
+          <template #default="{ row }">{{ formatAmount(row.amount) }}</template>
+        </el-table-column>
+        <el-table-column prop="status" label="状态" width="120" />
+        <el-table-column label="操作" width="180" fixed="right">
+          <template #default="{ row }">
+            <el-button link type="primary" @click="handleView(row)">查看</el-button>
+            <el-button link type="primary" :disabled="!canEdit(row)" @click="handleEdit(row)">编辑</el-button>
+          </template>
+        </el-table-column>
+        <template #empty>
+          <el-empty :description="loading ? '正在加载' : '暂无符合条件的数据'" />
+        </template>
+      </el-table>
+
+      <div class="pagination-row">
+        <el-pagination
+          v-model:current-page="pagination.page"
+          v-model:page-size="pagination.size"
+          :total="pagination.total"
+          :page-sizes="[10, 20, 50, 100]"
+          layout="total, sizes, prev, pager, next, jumper"
+          @current-change="loadRows"
+          @size-change="handleSizeChange"
+        />
+      </div>
+    </el-card>
+  </section>
+</template>
+
+<script setup>
+import { onMounted, reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+// TODO(matrix): replace with the owning feature API module.
+import { listRecords } from '@/api/replace-with-feature-api'
+
+const router = useRouter()
+const rows = ref([])
+const loading = ref(false)
+const errorMessage = ref('')
+let requestSequence = 0
+
+const filters = reactive({ keyword: '', status: '', sortField: '', sortOrder: '' })
+const pagination = reactive({ page: 1, size: 20, total: 0 })
+
+async function loadRows() {
+  const sequence = ++requestSequence
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const response = await listRecords({
+      page: pagination.page,
+      size: pagination.size,
+      keyword: filters.keyword || undefined,
+      status: filters.status || undefined,
+      sortField: filters.sortField || undefined,
+      sortOrder: filters.sortOrder || undefined,
+    })
+    if (sequence !== requestSequence) return
+    // TODO(matrix): normalize using the actual ApiResponse and pagination contract.
+    const pageData = response?.data?.data ?? response?.data ?? {}
+    rows.value = pageData.records ?? pageData.items ?? []
+    pagination.total = Number(pageData.total ?? 0)
+  } catch (error) {
+    if (sequence !== requestSequence) return
+    rows.value = []
+    pagination.total = 0
+    errorMessage.value = error?.response?.data?.message || error?.message || '数据加载失败'
+  } finally {
+    if (sequence === requestSequence) loading.value = false
+  }
+}
+
+function handleSearch() {
+  pagination.page = 1
+  loadRows()
+}
+
+function handleReset() {
+  Object.assign(filters, { keyword: '', status: '', sortField: '', sortOrder: '' })
+  pagination.page = 1
+  loadRows()
+}
+
+function handleSizeChange() {
+  pagination.page = 1
+  loadRows()
+}
+
+function handleSortChange({ prop, order }) {
+  filters.sortField = prop || ''
+  filters.sortOrder = order === 'ascending' ? 'ASC' : order === 'descending' ? 'DESC' : ''
+  pagination.page = 1
+  loadRows()
+}
+
+function formatAmount(value) {
+  if (value === null || value === undefined || value === '') return '—'
+  return new Intl.NumberFormat('zh-CN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value)
+}
+
+function canEdit(row) {
+  return ['DRAFT', 'REJECTED'].includes(row.status)
+}
+
+function handleCreate() {
+  router.push({ name: 'TODOCreateRoute' })
+}
+
+function handleView(row) {
+  router.push({ name: 'TODOViewRoute', params: { id: row.id } })
+}
+
+function handleEdit(row) {
+  if (canEdit(row)) router.push({ name: 'TODOEditRoute', params: { id: row.id } })
+}
+
+onMounted(loadRows)
+</script>
+
+<style scoped>
+.page-shell { padding: 20px; }
+.page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; margin-bottom: 16px; }
+.page-header h1 { margin: 0 0 6px; font-size: 22px; }
+.page-header p { margin: 0; color: var(--el-text-color-secondary); }
+.filter-card, .state-block { margin-bottom: 16px; }
+.pagination-row { display: flex; justify-content: flex-end; margin-top: 16px; overflow-x: auto; }
+</style>

--- a/.agents/skills/matrix-table-page/assets/vuetify-table-page-template.vue
+++ b/.agents/skills/matrix-table-page/assets/vuetify-table-page-template.vue
@@ -1,0 +1,177 @@
+<!-- Copy into src/views and replace every TODO(matrix) placeholder. -->
+<template>
+  <v-container fluid class="page-shell">
+    <div class="page-header">
+      <div>
+        <h1 class="text-h5 font-weight-bold">TODO(matrix): 页面标题</h1>
+        <p class="text-body-2 text-medium-emphasis">TODO(matrix): 说明组织、账簿、期间或业务范围。</p>
+      </div>
+      <v-btn color="primary" prepend-icon="mdi-plus" @click="handleCreate">新增</v-btn>
+    </div>
+
+    <v-card variant="outlined" class="mb-4">
+      <v-card-text>
+        <v-row dense align="center">
+          <v-col cols="12" md="4">
+            <v-text-field
+              v-model.trim="filters.keyword"
+              label="关键词"
+              placeholder="编号或名称"
+              clearable
+              hide-details
+              @keyup.enter="handleSearch"
+            />
+          </v-col>
+          <v-col cols="12" md="3">
+            <v-select
+              v-model="filters.status"
+              :items="statusOptions"
+              label="状态"
+              clearable
+              hide-details
+            />
+          </v-col>
+          <v-col cols="12" md="5" class="d-flex ga-2 justify-end">
+            <v-btn color="primary" :loading="loading" @click="handleSearch">查询</v-btn>
+            <v-btn variant="outlined" :disabled="loading" @click="handleReset">重置</v-btn>
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-card>
+
+    <v-alert v-if="errorMessage" type="error" variant="tonal" closable class="mb-4">
+      {{ errorMessage }}
+    </v-alert>
+
+    <v-card variant="outlined">
+      <v-data-table-server
+        v-model:page="pagination.page"
+        v-model:items-per-page="pagination.size"
+        :headers="headers"
+        :items="rows"
+        :items-length="pagination.total"
+        :loading="loading"
+        item-value="id"
+        @update:options="handleOptions"
+      >
+        <template #item.amount="{ item }">
+          <div class="text-right tabular-number">{{ formatAmount(item.amount) }}</div>
+        </template>
+        <template #item.actions="{ item }">
+          <v-btn size="small" variant="text" color="primary" @click="handleView(item)">查看</v-btn>
+          <v-btn size="small" variant="text" color="primary" :disabled="!canEdit(item)" @click="handleEdit(item)">编辑</v-btn>
+        </template>
+        <template #no-data>
+          <div class="pa-8 text-center text-medium-emphasis">暂无符合条件的数据</div>
+        </template>
+      </v-data-table-server>
+    </v-card>
+  </v-container>
+</template>
+
+<script setup>
+import { onMounted, reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+// TODO(matrix): replace with the owning feature API module.
+import { listRecords } from '@/api/replace-with-feature-api'
+
+const router = useRouter()
+const rows = ref([])
+const loading = ref(false)
+const errorMessage = ref('')
+let requestSequence = 0
+
+const statusOptions = [
+  { title: '草稿', value: 'DRAFT' },
+  { title: '已提交', value: 'SUBMITTED' },
+]
+const headers = [
+  { title: '编号', key: 'number', minWidth: 150 },
+  { title: '名称', key: 'name', minWidth: 200 },
+  { title: '金额', key: 'amount', align: 'end', minWidth: 140 },
+  { title: '状态', key: 'status', width: 120 },
+  { title: '操作', key: 'actions', sortable: false, width: 180 },
+]
+const filters = reactive({ keyword: '', status: '', sortField: '', sortOrder: '' })
+const pagination = reactive({ page: 1, size: 20, total: 0 })
+
+async function loadRows() {
+  const sequence = ++requestSequence
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const response = await listRecords({
+      page: pagination.page,
+      size: pagination.size,
+      keyword: filters.keyword || undefined,
+      status: filters.status || undefined,
+      sortField: filters.sortField || undefined,
+      sortOrder: filters.sortOrder || undefined,
+    })
+    if (sequence !== requestSequence) return
+    // TODO(matrix): normalize using the actual ApiResponse and pagination contract.
+    const pageData = response?.data?.data ?? response?.data ?? {}
+    rows.value = pageData.records ?? pageData.items ?? []
+    pagination.total = Number(pageData.total ?? 0)
+  } catch (error) {
+    if (sequence !== requestSequence) return
+    rows.value = []
+    pagination.total = 0
+    errorMessage.value = error?.response?.data?.message || error?.message || '数据加载失败'
+  } finally {
+    if (sequence === requestSequence) loading.value = false
+  }
+}
+
+function handleOptions(options) {
+  pagination.page = options.page || 1
+  pagination.size = options.itemsPerPage || 20
+  const sort = options.sortBy?.[0]
+  filters.sortField = sort?.key || ''
+  filters.sortOrder = sort?.order === 'asc' ? 'ASC' : sort?.order === 'desc' ? 'DESC' : ''
+  loadRows()
+}
+
+function handleSearch() {
+  pagination.page = 1
+  loadRows()
+}
+
+function handleReset() {
+  Object.assign(filters, { keyword: '', status: '', sortField: '', sortOrder: '' })
+  pagination.page = 1
+  loadRows()
+}
+
+function formatAmount(value) {
+  if (value === null || value === undefined || value === '') return '—'
+  return new Intl.NumberFormat('zh-CN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value)
+}
+
+function canEdit(row) {
+  return ['DRAFT', 'REJECTED'].includes(row.status)
+}
+
+function handleCreate() {
+  router.push({ name: 'TODOCreateRoute' })
+}
+
+function handleView(row) {
+  router.push({ name: 'TODOViewRoute', params: { id: row.id } })
+}
+
+function handleEdit(row) {
+  if (canEdit(row)) router.push({ name: 'TODOEditRoute', params: { id: row.id } })
+}
+
+onMounted(loadRows)
+</script>
+
+<style scoped>
+.page-shell { padding: 20px; }
+.page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; margin-bottom: 16px; }
+.tabular-number { font-variant-numeric: tabular-nums; }
+@media (max-width: 960px) {
+  .page-header { flex-direction: column; }
+}
+</style>

--- a/.agents/skills/matrix-ui/SKILL.md
+++ b/.agents/skills/matrix-ui/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: matrix-ui
+description: Design, implement, or revise Matrix Web pages and components. Use for layouts, navigation, dashboards, financial interfaces, responsive behavior, visual consistency, interaction states, accessibility, Element Plus, or Vuetify work.
+metadata:
+  author: micor
+  version: "1.0.0"
+---
+
+# Matrix UI Development
+
+## Objective
+
+Build professional, information-dense financial interfaces that remain readable, predictable, and maintainable during long working sessions.
+
+## Required context
+
+Before editing:
+
+1. Read `/AGENTS.md`.
+2. Locate the route and neighboring pages.
+3. Identify whether the surrounding feature uses Element Plus or Vuetify.
+4. Inspect existing shared components, layout containers, formatters, and styles.
+5. Confirm the backend contract if the page presents business data.
+6. Read `references/design-system.md` for substantial visual work.
+
+## Product character
+
+Matrix UI should feel:
+
+- Professional and restrained.
+- Data-oriented and efficient.
+- Stable across similar pages.
+- Clear about business scope and workflow state.
+- Suitable for desktop-heavy enterprise use.
+
+Avoid:
+
+- Decorative gradients without semantic purpose.
+- Oversized cards that reduce useful information density.
+- Consumer-app interaction patterns that hide business context.
+- Emoji as functional icons.
+- Motion that delays task completion.
+- Unexplained visual variation between similar modules.
+
+## Component-system rule
+
+The repository currently uses both Element Plus and Vuetify.
+
+For each change:
+
+1. Follow the library already used by the surrounding feature.
+2. Do not mix the two libraries inside one page unless a shared legacy component requires it.
+3. Do not add a third UI library.
+4. Prefer shared wrappers and tokens over page-specific overrides.
+5. Record intentional exceptions in the change summary.
+
+## Page composition
+
+A route-level page should normally contain:
+
+1. Page title and business context.
+2. Primary actions.
+3. Search, scope, or filter controls when relevant.
+4. Main content area.
+5. Loading, empty, error, and permission states.
+6. Pagination or summary information where needed.
+
+Keep business context visible. For financial pages, show organization, ledger, currency, and period when those dimensions affect meaning.
+
+## Interaction rules
+
+- Make the primary action visually clear but not oversized.
+- Place dangerous actions away from common navigation actions.
+- Confirm destructive, posting, reversal, closing, or other high-impact operations.
+- Disable repeated actions while requests are pending.
+- Preserve user context after recoverable errors.
+- Keep navigation and modal behavior predictable.
+- Do not use color as the only indication of success, warning, failure, or status.
+
+## Data presentation
+
+- Right-align amounts, quantities, rates, and percentages.
+- Use consistent decimal precision and currency presentation.
+- Use tabular numerals where the existing typography permits it.
+- Prevent status labels from shifting page layout excessively.
+- Provide tooltips or expansion for truncated business text.
+- Design for unusually large values and long identifiers.
+- Keep debit and credit visually distinct through labels and alignment, not color alone.
+
+## Responsive strategy
+
+Matrix is desktop-first, but pages must degrade intentionally:
+
+- Verify at approximately 1280px and 1920px widths.
+- Avoid fixed widths that cause unnecessary horizontal overflow.
+- Allow wide financial tables to scroll inside a controlled container.
+- Collapse secondary filters or actions before hiding primary business context.
+- Do not redesign desktop tables as decorative cards unless the use case genuinely requires a mobile view.
+
+## Accessibility
+
+- Controls must be keyboard reachable.
+- Inputs must have labels or accessible names.
+- Maintain visible focus states.
+- Modal focus and close behavior must be predictable.
+- Icons that carry meaning need accessible text.
+- Error messages must identify the problem and next action.
+
+## Implementation workflow
+
+1. Describe the user task and page states.
+2. Identify reusable neighboring patterns.
+3. Choose the existing component system for the feature.
+4. Define layout, hierarchy, actions, and responsive behavior.
+5. Implement with the smallest necessary component surface.
+6. Verify long text, large values, loading, empty, error, and permission cases.
+7. Run the production build.
+8. Review the change with `matrix-frontend-review`.
+
+## Verification
+
+At minimum:
+
+```bash
+npm run build
+```
+
+Also check:
+
+- Browser console errors.
+- Keyboard navigation.
+- 1280px and 1920px layouts.
+- Long labels and large numeric values.
+- Empty and failed API responses.
+- Duplicate action prevention.
+
+## Completion report
+
+State:
+
+- Pages and components changed.
+- Existing patterns and component library reused.
+- States and widths checked.
+- Build result.
+- Remaining visual or integration risks.

--- a/.agents/skills/matrix-ui/references/design-system.md
+++ b/.agents/skills/matrix-ui/references/design-system.md
@@ -1,0 +1,130 @@
+# Matrix Web Design-System Reference
+
+## Purpose
+
+This reference defines stable visual and interaction principles for Matrix Web. It is not a mandate to rewrite existing pages. Apply it incrementally when creating or revising features.
+
+## 1. Visual hierarchy
+
+Use hierarchy in this order:
+
+1. Page and business context.
+2. Primary workflow action.
+3. Search or scope controls.
+4. Main business data.
+5. Secondary summaries and supporting information.
+
+Do not let decorative containers compete with business data.
+
+## 2. Spacing
+
+Use a restrained spacing scale and reuse existing tokens where present.
+
+Recommended conceptual scale:
+
+- 4px: icon/text micro-gap.
+- 8px: compact control or inline gap.
+- 12px: related controls.
+- 16px: normal section padding.
+- 24px: section separation.
+- 32px: major page separation.
+
+Avoid arbitrary one-off values when a nearby page already establishes a pattern.
+
+## 3. Typography
+
+- Page titles should be clear but not oversized.
+- Body and table text must remain readable at enterprise information density.
+- Use weight and spacing before relying on additional colors.
+- Numeric columns should align consistently.
+- Avoid decorative typefaces.
+
+## 4. Color
+
+- Reuse the active component library theme and project variables.
+- Use semantic colors for success, warning, error, and information.
+- Do not use color as the only status indicator.
+- Maintain readable contrast for text, borders, disabled states, and focus indicators.
+- Avoid adding custom color values directly to many components; centralize reusable values.
+
+## 5. Surfaces and borders
+
+- Use cards or panels to express grouping, not to wrap every element.
+- Prefer subtle borders and restrained shadows.
+- Keep table, form, and report surfaces visually consistent within one feature.
+- Do not add gradients without a documented semantic purpose.
+
+## 6. Actions
+
+- One clear primary action per local context.
+- Secondary actions should not compete with the primary action.
+- Dangerous actions require distinct wording and confirmation.
+- Avoid ambiguous labels such as “确定” when a precise verb such as “过账” or “冲销” is available.
+- Pending actions must communicate progress and prevent duplicate execution.
+
+## 7. Statuses
+
+Status components should include readable text. When practical, also provide an icon, border, or shape difference so status is not color-only.
+
+Keep terminology aligned with backend values and domain language. Do not invent alternative status names for visual convenience.
+
+## 8. Financial values
+
+- Right-align amounts.
+- Preserve required decimal precision.
+- Include currency when scope is not obvious.
+- Distinguish negative values consistently.
+- Do not perform authoritative totals with JavaScript floating-point arithmetic.
+- Large values should not overlap adjacent columns or controls.
+
+## 9. Tables
+
+- Header labels should be concise and unambiguous.
+- Sticky headers or columns should be used only when they improve navigation through wide datasets.
+- Dense data is acceptable; illegible data is not.
+- Avoid excessive action buttons in every row. Use a compact action group or menu when necessary.
+- Horizontal scrolling should remain inside the table region rather than the entire page.
+
+## 10. Forms
+
+- Group fields by business meaning.
+- Put required and validation indicators close to labels.
+- Keep form actions predictable and visible.
+- Preserve input after recoverable server failures.
+- Read-only business fields should look read-only, not disabled without explanation.
+
+## 11. Empty, loading, and error states
+
+Loading:
+
+- Show skeletons, spinners, or table loading states appropriate to the content.
+- Avoid replacing the entire page for small background refreshes.
+
+Empty:
+
+- Explain whether no data exists or filters produced no results.
+- Offer a relevant next action only when permitted.
+
+Error:
+
+- State what failed and what the user can do.
+- Preserve filters and form input where possible.
+- Do not expose stack traces or sensitive payloads.
+
+## 12. Modals and drawers
+
+- Use modals for focused decisions or compact edits.
+- Use drawers when context should remain visible or the content is longer.
+- Avoid stacking multiple modals.
+- Restore focus when the overlay closes.
+- Confirm before closing when unsaved changes would be lost.
+
+## 13. Component-library coexistence
+
+Because Matrix Web currently includes Element Plus and Vuetify:
+
+1. Follow the library used by the feature being changed.
+2. Do not mix visual primitives from both libraries in one new page.
+3. Wrap repeated patterns behind project components where useful.
+4. Do not attempt a broad migration during unrelated feature work.
+5. When a feature is intentionally migrated, define the scope and verify all affected interactions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+Follow the repository-wide instructions in `/AGENTS.md`.
+
+Canonical task workflows are stored under `/.agents/skills/`.
+
+Before changing frontend code:
+
+1. Identify the affected route, feature, component library, and backend contract.
+2. Read every applicable skill referenced by `AGENTS.md`.
+3. Handle loading, empty, error, permission, and success states deliberately.
+4. Review duplicate writes, request races, financial presentation, accessibility, and responsive behavior.
+5. Run `npm run build` and report validation and remaining risks.
+
+Do not duplicate the canonical rules in this file.

--- a/.github/workflows/agent-skills-validation.yml
+++ b/.github/workflows/agent-skills-validation.yml
@@ -1,0 +1,71 @@
+name: Agent Skills Validation
+
+on:
+  pull_request:
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '.agents/**'
+      - '.github/copilot-instructions.md'
+      - 'src/**'
+      - 'public/**'
+      - 'vite.config.*'
+      - '.env*'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '.agents/**'
+      - '.github/copilot-instructions.md'
+      - 'src/**'
+      - 'public/**'
+      - 'vite.config.*'
+      - '.env*'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate skill structure
+        run: python .agents/scripts/validate_skills.py
+
+      - name: Resolve changed frontend files
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${BASE_SHA}" || "${BASE_SHA}" == "0000000000000000000000000000000000000000" ]]; then
+            BASE_SHA="$(git rev-parse HEAD^)"
+          fi
+          git diff --name-only --diff-filter=ACMR "${BASE_SHA}" "${GITHUB_SHA}" \
+            | grep -E '^(src/|public/|vite\.config\.|\.env)' \
+            > /tmp/changed-frontend-files.txt || true
+          cat /tmp/changed-frontend-files.txt
+
+      - name: Scan changed frontend sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t files < /tmp/changed-frontend-files.txt
+          if (( ${#files[@]} )); then
+            node .agents/skills/matrix-frontend-review/scripts/scan-sensitive-logs.mjs "${files[@]}"
+          else
+            echo 'No changed runtime frontend files.'
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,193 @@
-# Workspace Context
+# Matrix Web Repository Instructions
 
-This workspace is developed together with a sibling backend repository.
+## 1. Workspace context
 
-When a task involves "development", "fixing bugs", "adding features", "联调", or "writing code", always consider both of these directories first:
+Matrix Web is the frontend application for the Matrix enterprise intelligent finance platform. It is developed together with the sibling backend repository `matrix`.
+
+When a task involves development, bug fixing, feature work, API integration, permissions, finance workflows, or end-to-end behavior, consider both repositories:
+
+- Frontend: `matrix-web`
+- Backend: `matrix`
+
+Local development currently uses:
 
 - Frontend: `C:\Users\20602\IdeaProjects\matrix-web`
 - Backend: `C:\Users\20602\IdeaProjects\matrix`
 
-Working convention:
+Use these paths only when they exist. Do not assume every AI agent or CI runner uses the same filesystem.
 
-1. If the request is about pages, components, routes, UI, browser behavior, frontend API calls, or Vite/Vue code, work in `matrix-web`.
-2. If the request is about Java services, Spring Boot, gateway/auth/finance modules, MyBatis-Plus, configuration, or backend interfaces, work in `matrix`.
-3. If the request sounds like integration, end-to-end flow, data mismatch, login, permissions, vouchers, ledgers, or base data maintenance, inspect both repositories before making changes.
-4. Unless the user explicitly narrows the scope, assume these two repositories are part of the same project and should be considered together.
+Routing rules:
 
-Quick project notes:
+1. Vue pages, components, routes, UI behavior, browser state, frontend API clients, and Vite configuration belong primarily to `matrix-web`.
+2. Java services, Spring Boot, gateway, authentication, finance services, database behavior, and backend contracts belong primarily to `matrix`.
+3. Login, permissions, vouchers, ledgers, reports, master data, AR/AP, and integration failures may require inspecting both repositories.
+4. Do not invent frontend fields, statuses, or endpoint contracts when the backend implementation can be inspected.
 
-- `matrix-web` is a Vue 3 + Vite frontend and currently uses `vue-router`, `axios`, `pinia`, and `vuetify`.
-- `matrix` is a Java 17 Maven multi-module backend using Spring Boot, Spring Cloud Alibaba, and MyBatis-Plus.
+## 2. Product positioning
 
-Default expectation for future threads:
+Matrix Web is an enterprise financial application. Its interface should be professional, information-dense, stable, and suitable for long working sessions.
 
-- Re-establish context from this file before starting substantial work.
-- Do not assume only the current working directory matters; check whether the sibling repository is also relevant.
+Avoid consumer-app decoration, oversized cards, unnecessary gradients, decorative animation, emoji as functional icons, and visual patterns that reduce information density without improving comprehension.
+
+## 3. Technology baseline
+
+- Vue 3.5
+- Vite 6
+- Vue Router 4
+- Pinia 3
+- Axios 1
+- Sass
+- Element Plus
+- Vuetify
+
+Do not silently upgrade dependencies or add another UI framework.
+
+The codebase currently contains both Element Plus and Vuetify. For new work:
+
+- Reuse the component system already used by the surrounding feature.
+- Do not mix Element Plus and Vuetify inside one page unless an existing shared component requires it.
+- Do not introduce a third component library.
+- Prefer gradual convergence over broad visual rewrites.
+
+## 4. Source responsibilities
+
+- `src/views`: route-level pages and feature views.
+- `src/components`: reusable components with clear contracts.
+- `src/router`: route definitions, navigation guards, and route metadata.
+- `src/stores`: shared application state only; avoid using stores as a replacement for local component state.
+- `src/api` or existing request modules: backend API access.
+- `src/utils`: framework-independent utilities and shared browser helpers.
+- `src/assets`: static resources and shared visual assets.
+
+Follow the current repository structure when a nearby feature already establishes a convention.
+
+## 5. Mandatory Vue rules
+
+- Use Vue 3 Composition API for new substantial components.
+- Keep route pages focused on orchestration; extract reusable or complex sections into components.
+- Do not duplicate request, formatting, or permission logic across pages.
+- Use computed state for derived values instead of synchronizing duplicate state manually.
+- Clean up timers, subscriptions, listeners, and in-flight work when appropriate.
+- Do not mutate props.
+- Use stable keys for lists; never use the array index when row identity exists.
+- Keep page-specific state local unless multiple routes genuinely share it.
+- Do not hide business-critical behavior inside visual components without an explicit component contract.
+
+## 6. Enterprise UI requirements
+
+Every data-oriented page must intentionally support the relevant states:
+
+- Initial loading
+- Background refresh
+- Empty result
+- Request failure
+- Permission denied
+- Partial data or unavailable fields
+- Long text and large numeric values
+- Slow or repeated user actions
+
+Financial UI rules:
+
+- Right-align monetary and quantity columns.
+- Format monetary values consistently and preserve precision required by the API.
+- Never use JavaScript floating-point arithmetic for authoritative financial calculations.
+- Display organization, ledger, currency, and accounting period context prominently when they affect meaning.
+- Clearly distinguish debit and credit.
+- Do not rely on color alone to communicate status or risk.
+- Require confirmation for destructive or irreversible financial actions.
+- Preserve filters and pagination when returning from detail or edit pages where practical.
+- Prevent duplicate submissions while write requests are pending.
+
+## 7. Forms
+
+- Define defaults intentionally; do not let `undefined`, empty string, and `null` become interchangeable by accident.
+- Keep client-side rules aligned with backend validation.
+- Do not claim success until the server confirms the write.
+- Surface field-level validation when possible and preserve user input after recoverable failures.
+- Disable or guard repeated submission.
+- Distinguish create, edit, view, audit, and other workflow modes explicitly.
+- Financial records must respect backend state restrictions; do not expose edit actions for immutable states.
+
+## 8. Tables and reports
+
+- Keep filters, pagination, sorting, and URL or navigation state coherent.
+- Use backend pagination for potentially large datasets.
+- Do not load entire financial datasets into the browser merely to paginate or aggregate locally.
+- Use explicit empty, loading, and error presentations instead of blank tables.
+- Right-align numbers and use consistent date, status, amount, and currency formatters.
+- For reports, state the scope and avoid silently combining different currencies, organizations, ledgers, or periods.
+- Export behavior must match current filters and scope.
+
+## 9. API integration
+
+- Reuse the repository's request abstraction and authentication handling.
+- Do not call Axios directly from many components when a feature API module can centralize the contract.
+- Treat backend DTOs and enums as the source of truth.
+- Normalize response handling in the API layer, not repeatedly in templates.
+- Handle unauthorized, forbidden, validation, conflict, and server errors deliberately.
+- Cancel or ignore stale responses when rapid navigation or repeated searches can race.
+- Never log tokens, credentials, personal information, or sensitive financial payloads.
+
+Read `.agents/skills/matrix-api-integration/SKILL.md` before substantial API integration work.
+
+## 10. Accessibility and interaction
+
+- Interactive controls must be keyboard reachable.
+- Inputs require associated labels or equivalent accessible names.
+- Modal focus and close behavior must be predictable.
+- Do not communicate state only through color.
+- Maintain visible focus states.
+- Use concise, actionable error messages.
+- Avoid unexpected navigation or destructive actions without confirmation.
+
+## 11. Skill routing
+
+Read every applicable skill before implementation:
+
+- General UI, layout, components, responsive behavior, design consistency:
+  `.agents/skills/matrix-ui/SKILL.md`
+- Search forms, data tables, pagination, sorting, exports:
+  `.agents/skills/matrix-table-page/SKILL.md`
+- Create/edit/view forms, validation, submit behavior:
+  `.agents/skills/matrix-form-page/SKILL.md`
+- Axios, endpoints, DTO mapping, auth, error handling, integration:
+  `.agents/skills/matrix-api-integration/SKILL.md`
+- Review, regression risk, accessibility, pre-merge checks:
+  `.agents/skills/matrix-frontend-review/SKILL.md`
+
+A task may require multiple skills. A voucher edit page, for example, normally requires UI, form-page, API-integration, and frontend-review skills.
+
+## 12. Development workflow
+
+1. Identify the route, feature, and neighboring implementation pattern.
+2. Read applicable skills and references.
+3. Confirm the backend contract for data, statuses, permissions, and errors.
+4. Define loading, empty, error, permission, and success states.
+5. Implement the smallest complete change.
+6. Check keyboard behavior, responsive layout, and long-content behavior.
+7. Run the production build.
+8. Review API races, duplicate submission, permissions, financial presentation, and regression risks.
+9. Report changed files, behavior, validation, and remaining risks.
+
+## 13. Validation commands
+
+```bash
+npm install
+npm run build
+npm run dev
+```
+
+Use the repository's existing package manager and lockfile. Do not replace the lockfile or package manager without an explicit migration decision.
+
+## 14. Definition of done
+
+A frontend change is complete only when:
+
+- The intended user flow works end to end.
+- Loading, empty, error, and permission states are handled where relevant.
+- Backend contracts and financial statuses are respected.
+- Duplicate submission and stale-response risks have been considered.
+- Layout, keyboard behavior, long text, and large values have been checked.
+- The production build passes.
+- No secret, token, sensitive payload, generated artifact, or unrelated dependency was introduced.
+- The final report states what changed, how it was validated, and any remaining risks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+@AGENTS.md
+
+# Claude-specific routing
+
+Canonical project skills are stored under `.agents/skills/`.
+
+Before substantial implementation, read every applicable `SKILL.md` referenced by `AGENTS.md`.
+
+Do not duplicate or replace the canonical project rules in this file.


### PR DESCRIPTION
## What changed

### Repository instructions

- Expanded `AGENTS.md` into the frontend AI instruction entry point while preserving the sibling `matrix` backend context.
- Added five canonical Matrix Web skills:
  - UI and design consistency
  - Table and report pages
  - Form and workflow pages
  - API integration
  - Frontend review
- Added visual-system and asynchronous-state references.
- Added lightweight Claude and GitHub Copilot entry points without duplicating the canonical rules.

### Reusable implementation assets

Added copy-and-adapt templates for both component systems already present in the repository:

- Element Plus table page
- Vuetify table page
- Element Plus form page
- Vuetify form page

The templates include loading, empty, error, pagination, request-race protection, exact amount transport guidance, duplicate-submit protection, unsaved-change confirmation, and workflow-state-aware actions.

Also added an API contract checklist covering DTOs, pagination, enum/date/amount formats, errors, state conflicts, permissions, retries, and UI-state mapping.

### Executable validation

- Added Skill structure validation.
- Added changed-source scanning for sensitive console logging, hard-coded bearer values, private keys, `v-html`, unsafe `_blank` links, and fixed public service addresses.
- Added `.agents/VALIDATION.md` with commands and asset paths.

### CI

Added `Agent Skills Validation`, which:

- validates the Skill structure on every relevant PR;
- scans only changed runtime frontend files;
- avoids checking unrelated historical source files when the PR changes only agent documentation or assets.

## Key decisions

- Matrix Web remains desktop-first and data-oriented.
- New work follows the component library used by the surrounding feature.
- Element Plus and Vuetify should not be mixed unnecessarily within one page.
- No third UI component library should be introduced.
- Financial precision, workflow states, request races, duplicate writes, accessibility, and error states remain explicit review concerns.

## Impact

This PR changes AI instructions, validation scripts, templates, and CI only. It does not change imported Vue runtime code, dependencies, routes, or API behavior.

## Validation

- Branch compared against `main`: 21 changed files, branch is not behind.
- `Agent Skills Validation` workflow run `30456760674` completed successfully.
- `npm run build` was not run because the new `.vue` files are unimported templates under `.agents/`, not runtime source files.

## Remaining follow-up

After merge, the next real frontend feature should copy the matching template, replace all `TODO(matrix)` markers, verify the backend contract, run the production build, and complete browser smoke testing.