### PR TITLE
feat(knowledge): add knowledge base workbench

### DIFF
--- a/.github/workflows/knowledge-web-ci.yml
+++ b/.github/workflows/knowledge-web-ci.yml
@@ -1,0 +1,43 @@
+name: Knowledge Web CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - 'src/views/ai/**'
+      - 'src/api/ai.js'
+      - 'src/router/index.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/knowledge-web-ci.yml'
+  push:
+    branches:
+      - dev
+      - 'agent/knowledge-*'
+    paths:
+      - 'src/views/ai/**'
+      - 'src/api/ai.js'
+      - 'src/router/index.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/knowledge-web-ci.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build knowledge workbench
+        run: npm run build

--- a/src/api/ai.js
+++ b/src/api/ai.js
@@ -32,6 +32,31 @@ export function submitAiFeedback(data) {
   })
 }
 
+export function listKnowledgeBases(params = {}) {
+  return request.get('/ai/knowledge/bases', {
+    params,
+    timeout: AI_REQUEST_TIMEOUT,
+  })
+}
+
+export function createKnowledgeBase(data) {
+  return request.post('/ai/knowledge/bases', data, {
+    timeout: AI_REQUEST_TIMEOUT,
+  })
+}
+
+export function updateKnowledgeBase(kbId, data) {
+  return request.put(`/ai/knowledge/bases/${kbId}`, data, {
+    timeout: AI_REQUEST_TIMEOUT,
+  })
+}
+
+export function deleteKnowledgeBase(kbId) {
+  return request.delete(`/ai/knowledge/bases/${kbId}`, {
+    timeout: AI_REQUEST_TIMEOUT,
+  })
+}
+
 export function listKnowledgeDocs(params = {}) {
   return request.get('/ai/knowledge/docs', {
     params,
@@ -65,6 +90,12 @@ export function deleteKnowledgeDoc(docId) {
 
 export function rebuildKnowledgeDoc(docId) {
   return request.post(`/ai/knowledge/docs/${docId}/rebuild`, {}, {
+    timeout: AI_REQUEST_TIMEOUT,
+  })
+}
+
+export function reindexKnowledgeDoc(docId) {
+  return request.post(`/ai/knowledge/docs/${docId}/reindex-vector`, {}, {
     timeout: AI_REQUEST_TIMEOUT,
   })
 }

--- a/src/views/ai/AiAssistantView.vue
+++ b/src/views/ai/AiAssistantView.vue
@@ -40,9 +40,23 @@
 
       <v-col cols="12" md="9">
         <v-card class="h-100 d-flex flex-column" variant="outlined">
-          <v-card-title class="d-flex align-center justify-space-between">
+          <v-card-title class="assistant-heading">
             <span>AI 助手（完整版）</span>
-            <div class="d-flex align-center ga-2">
+            <div class="assistant-actions">
+              <v-select
+                v-model="selectedKbIds"
+                :items="knowledgeBaseItems"
+                item-title="title"
+                item-value="value"
+                label="知识范围"
+                multiple
+                chips
+                closable-chips
+                density="compact"
+                hide-details
+                variant="outlined"
+                class="kb-select"
+              />
               <v-btn variant="tonal" size="small" prepend-icon="mdi-book-open-page-variant-outline" @click="router.push('/ai/knowledge')">
                 知识系统
               </v-btn>
@@ -69,7 +83,7 @@
                   v-for="citation in msg.citations"
                   :key="citation.chunkId"
                   type="button"
-                  @click="router.push('/ai/knowledge')"
+                  @click="openCitation(citation)"
                 >
                   <v-icon size="14">mdi-link-variant</v-icon>
                   <span>{{ citation.docName || citation.docId }}</span>
@@ -105,7 +119,13 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { chatWithAiStream, createConversation, getAiConfigStatus, getConversationMessages } from '@/api/ai'
+import {
+  chatWithAiStream,
+  createConversation,
+  getAiConfigStatus,
+  getConversationMessages,
+  listKnowledgeBases,
+} from '@/api/ai'
 
 const router = useRouter()
 const conversations = ref([])
@@ -115,6 +135,8 @@ const sending = ref(false)
 const messages = ref({})
 const configStatus = ref({ configured: false, model: '', mode: 'fallback' })
 const messagePanelRef = ref(null)
+const knowledgeBases = ref([])
+const selectedKbIds = ref(['default'])
 
 const activeMessages = computed(() => messages.value[activeConversationId.value] || [])
 const configModeText = computed(() => {
@@ -122,13 +144,17 @@ const configModeText = computed(() => {
   if (configStatus.value.mode === 'fallback') return '降级占位模式'
   return configStatus.value.mode || '未知模式'
 })
+const knowledgeBaseItems = computed(() => [
+  { title: '全部知识库', value: 'all' },
+  ...knowledgeBases.value
+    .filter(item => item.status === 'ACTIVE')
+    .map(item => ({ title: `${item.name}（${item.documentCount || 0}）`, value: item.kbId })),
+])
 
 function scrollToBottom() {
   requestAnimationFrame(() => {
     const el = messagePanelRef.value?.$el || messagePanelRef.value
-    if (el) {
-      el.scrollTop = el.scrollHeight
-    }
+    if (el) el.scrollTop = el.scrollHeight
   })
 }
 
@@ -141,6 +167,19 @@ async function refreshConfigStatus() {
   }
 }
 
+async function refreshKnowledgeBases() {
+  try {
+    const resp = await listKnowledgeBases({ status: 'ACTIVE' })
+    knowledgeBases.value = resp?.data || []
+    if (!knowledgeBases.value.some(item => selectedKbIds.value.includes(item.kbId))) {
+      selectedKbIds.value = knowledgeBases.value.some(item => item.kbId === 'default') ? ['default'] : ['all']
+    }
+  } catch (error) {
+    knowledgeBases.value = []
+    selectedKbIds.value = ['all']
+  }
+}
+
 async function createConversationAction() {
   const seq = conversations.value.length + 1
   const resp = await createConversation({ title: `新会话 ${seq}`, scene: 'knowledge_qa' })
@@ -149,16 +188,14 @@ async function createConversationAction() {
   if (!id) return
 
   conversations.value.unshift({ id, title })
-  messages.value[id] = [{ role: 'assistant', text: '你好，我已经准备好了。你可以继续追问，不用每次重复背景。' }]
+  messages.value[id] = [{ role: 'assistant', text: '你好，我已经准备好了。可以选择知识库后继续提问。' }]
   activeConversationId.value = id
   scrollToBottom()
 }
 
 async function selectConversation(conversationId) {
   activeConversationId.value = conversationId
-  if (!messages.value[conversationId] || messages.value[conversationId].length === 0) {
-    await loadMessages(conversationId)
-  }
+  if (!messages.value[conversationId]?.length) await loadMessages(conversationId)
   scrollToBottom()
 }
 
@@ -167,7 +204,7 @@ async function loadMessages(conversationId) {
     const resp = await getConversationMessages(conversationId)
     const list = resp?.data?.messages || []
     messages.value[conversationId] = list.map(item => ({ role: item.role, text: item.content }))
-  } catch (e) {
+  } catch (error) {
     if (!messages.value[conversationId]) {
       messages.value[conversationId] = [{ role: 'assistant', text: '历史消息加载失败，请稍后重试。' }]
     }
@@ -176,15 +213,23 @@ async function loadMessages(conversationId) {
 }
 
 function clearCurrentMessages() {
-  if (!activeConversationId.value) return
-  messages.value[activeConversationId.value] = []
+  if (activeConversationId.value) messages.value[activeConversationId.value] = []
+}
+
+function openCitation(citation) {
+  router.push({
+    path: '/ai/knowledge',
+    query: {
+      docId: citation.docId,
+      chunkId: citation.chunkId,
+    },
+  })
 }
 
 function updateMessage(conversationId, index, patch) {
   const list = messages.value[conversationId]
   const current = list?.[index]
-  if (!current) return
-  list.splice(index, 1, { ...current, ...patch })
+  if (current) list.splice(index, 1, { ...current, ...patch })
 }
 
 function appendMessageText(conversationId, index, delta = '') {
@@ -199,19 +244,13 @@ function getMessageText(conversationId, index) {
 
 async function send() {
   const text = input.value.trim()
-  if (!text || sending.value) return
+  if (!text || sending.value || !activeConversationId.value) return
   const conversationId = activeConversationId.value
-  if (!conversationId) return
-
-  if (!messages.value[conversationId]) {
-    messages.value[conversationId] = []
-  }
+  if (!messages.value[conversationId]) messages.value[conversationId] = []
 
   messages.value[conversationId].push({ role: 'user', text })
   input.value = ''
   sending.value = true
-  scrollToBottom()
-
   const assistantIndex = messages.value[conversationId].push({ role: 'assistant', text: '', citations: [] }) - 1
   scrollToBottom()
 
@@ -220,56 +259,38 @@ async function send() {
       {
         conversationId,
         userMessage: text,
-        kbIds: ['default'],
+        kbIds: selectedKbIds.value.length ? selectedKbIds.value : ['all'],
         stream: true,
       },
       {
         onStart(payload) {
           updateMessage(conversationId, assistantIndex, { citations: payload?.citations || [] })
-          if (payload?.conversationId) {
-            activeConversationId.value = payload.conversationId
-          }
-          if (payload?.model) {
-            configStatus.value.model = payload.model
-          }
-          if (payload?.mode) {
-            configStatus.value.mode = payload.mode
-          }
+          if (payload?.model) configStatus.value.model = payload.model
+          if (payload?.mode) configStatus.value.mode = payload.mode
         },
         onDelta(payload) {
           appendMessageText(conversationId, assistantIndex, payload?.delta || '')
           scrollToBottom()
         },
         onDone(payload) {
-          const currentCitations = messages.value[conversationId]?.[assistantIndex]?.citations || []
-          updateMessage(conversationId, assistantIndex, { citations: payload?.citations || currentCitations })
+          const citations = messages.value[conversationId]?.[assistantIndex]?.citations || []
+          updateMessage(conversationId, assistantIndex, { citations: payload?.citations || citations })
           if (!getMessageText(conversationId, assistantIndex).trim()) {
             updateMessage(conversationId, assistantIndex, { text: payload?.answer || '抱歉，暂时没有生成回复。' })
           }
-          if (payload?.mode) {
-            configStatus.value.mode = payload.mode
-            if (payload.mode === 'real-model') {
-              configStatus.value.configured = true
-            }
-          }
-          if (payload?.model) {
-            configStatus.value.model = payload.model
-          }
+          if (payload?.mode) configStatus.value.mode = payload.mode
+          if (payload?.model) configStatus.value.model = payload.model
+          if (payload?.mode === 'real-model') configStatus.value.configured = true
           scrollToBottom()
         },
         onError(payload) {
           if (!getMessageText(conversationId, assistantIndex).trim()) {
             updateMessage(conversationId, assistantIndex, { text: payload?.message || 'AI 服务暂不可用，请稍后重试。' })
           }
-          scrollToBottom()
         },
       }
     )
-
-    if (!getMessageText(conversationId, assistantIndex).trim()) {
-      updateMessage(conversationId, assistantIndex, { text: '抱歉，暂时没有生成回复。' })
-    }
-  } catch (e) {
+  } catch (error) {
     if (!getMessageText(conversationId, assistantIndex).trim()) {
       updateMessage(conversationId, assistantIndex, { text: 'AI 服务暂不可用，请稍后重试。' })
     }
@@ -280,7 +301,7 @@ async function send() {
 }
 
 onMounted(async () => {
-  await refreshConfigStatus()
+  await Promise.all([refreshConfigStatus(), refreshKnowledgeBases()])
   await createConversationAction()
 })
 </script>
@@ -295,7 +316,28 @@ onMounted(async () => {
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
 }
 
+.assistant-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.assistant-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.kb-select {
+  min-width: 260px;
+  max-width: 420px;
+}
+
 .message-panel {
+  min-height: 560px;
   background: linear-gradient(180deg, #fafcff 0%, #f7f9fc 100%);
 }
 
@@ -312,6 +354,16 @@ onMounted(async () => {
   margin-bottom: 12px;
   line-height: 1.6;
   box-shadow: 0 2px 8px rgba(15, 23, 42, 0.04);
+}
+
+.msg.user {
+  margin-left: auto;
+  background: #e8f1ff;
+}
+
+.msg.assistant {
+  margin-right: auto;
+  background: #ffffff;
 }
 
 .msg-role {
@@ -333,25 +385,26 @@ onMounted(async () => {
 }
 
 .msg-citations button {
-  min-height: 26px;
+  min-height: 28px;
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  padding: 0 8px;
-  border: 1px solid rgba(26, 42, 58, 0.1);
-  border-radius: 8px;
-  color: #17696a;
-  background: #eef8f5;
-  font-size: 12px;
+  padding: 0 9px;
+  border: 1px solid rgba(25, 118, 210, 0.18);
+  border-radius: 999px;
+  color: #155b9b;
+  background: #eff7ff;
   cursor: pointer;
 }
 
-.msg.user {
-  margin-left: auto;
-  background: #e8f1ff;
-}
+@media (max-width: 960px) {
+  .kb-select {
+    min-width: 100%;
+    max-width: 100%;
+  }
 
-.msg.assistant {
-  background: #ffffff;
+  .message-panel {
+    min-height: 420px;
+  }
 }
 </style>

--- a/src/views/ai/KnowledgeSystemView.vue
+++ b/src/views/ai/KnowledgeSystemView.vue
@@ -3,102 +3,131 @@
     <section class="hero-row">
       <div>
         <span class="eyebrow">Matrix Knowledge</span>
-        <h1>知识系统</h1>
-        <p>制度、流程、案例和业务口径在这里沉淀，并作为 AI 助手的可追溯引用来源。</p>
+        <h1>企业知识系统</h1>
+        <p>按知识库组织制度、流程、案例和业务口径，并作为 AI 助手可追溯的引用来源。</p>
       </div>
       <div class="hero-actions">
-        <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreateDialog">新建知识</v-btn>
-        <v-btn variant="tonal" prepend-icon="mdi-robot-outline" @click="goAssistant">AI 助手</v-btn>
+        <v-btn color="primary" prepend-icon="mdi-database-plus-outline" @click="openBaseCreate">新建知识库</v-btn>
+        <v-btn color="white" variant="tonal" prepend-icon="mdi-file-plus-outline" @click="openDocCreate">新建文档</v-btn>
+        <v-btn color="white" variant="text" prepend-icon="mdi-robot-outline" @click="router.push('/ai/assistant')">AI 助手</v-btn>
       </div>
     </section>
 
     <section class="metric-row">
-      <div class="metric-tile">
+      <article class="metric-card">
+        <span>知识库</span>
+        <strong>{{ knowledgeBases.length }}</strong>
+        <small>{{ activeBaseCount }} 个启用</small>
+      </article>
+      <article class="metric-card">
         <span>文档总数</span>
         <strong>{{ total }}</strong>
-        <small>当前筛选范围</small>
-      </div>
-      <div class="metric-tile">
-        <span>启用文档</span>
-        <strong>{{ activeDocCount }}</strong>
-        <small>本页可检索</small>
-      </div>
-      <div class="metric-tile">
-        <span>分片数量</span>
-        <strong>{{ selectedDetail?.chunkCount || currentPageChunkCount }}</strong>
-        <small>{{ selectedDetail ? '当前文档' : '本页合计' }}</small>
-      </div>
-      <div class="metric-tile">
-        <span>分类</span>
+        <small>{{ selectedBaseName }}</small>
+      </article>
+      <article class="metric-card">
+        <span>当前页分片</span>
+        <strong>{{ currentPageChunkCount }}</strong>
+        <small>向量检索最小单元</small>
+      </article>
+      <article class="metric-card">
+        <span>知识分类</span>
         <strong>{{ categories.length }}</strong>
-        <small>知识域</small>
-      </div>
+        <small>跨知识库分类</small>
+      </article>
     </section>
 
     <section class="workspace-grid">
-      <aside class="filter-panel">
-        <div class="panel-heading">
-          <span>Filter</span>
-          <strong>筛选</strong>
-        </div>
-        <v-text-field
-          v-model="filters.keyword"
-          density="comfortable"
-          hide-details
-          label="关键词"
-          prepend-inner-icon="mdi-magnify"
-          variant="outlined"
-          @keydown.enter="fetchDocs"
-        />
-        <v-select
-          v-model="filters.category"
-          :items="categoryItems"
-          density="comfortable"
-          hide-details
-          item-title="label"
-          item-value="value"
-          label="分类"
-          variant="outlined"
-        />
-        <v-select
-          v-model="filters.status"
-          :items="statusFilterItems"
-          density="comfortable"
-          hide-details
-          item-title="label"
-          item-value="value"
-          label="状态"
-          variant="outlined"
-        />
-        <div class="filter-actions">
-          <v-btn color="primary" block prepend-icon="mdi-filter-outline" @click="applyFilters">应用</v-btn>
-          <v-btn variant="text" block @click="resetFilters">重置</v-btn>
+      <aside class="panel base-panel">
+        <div class="panel-title">
+          <div>
+            <span>Knowledge Bases</span>
+            <strong>知识库</strong>
+          </div>
+          <v-btn icon="mdi-refresh" size="small" variant="text" :loading="baseLoading" @click="refreshAll" />
         </div>
 
-        <div class="category-stack">
+        <button
+          type="button"
+          class="base-item"
+          :class="{ active: selectedKbId === 'all' }"
+          @click="selectBase('all')"
+        >
+          <div>
+            <strong>全部知识</strong>
+            <small>跨知识库检索</small>
+          </div>
+          <v-chip size="x-small" variant="tonal">{{ allDocumentCount }}</v-chip>
+        </button>
+
+        <div v-for="base in knowledgeBases" :key="base.kbId" class="base-item-wrap">
           <button
-            v-for="category in categories"
-            :key="category"
             type="button"
-            :class="{ active: filters.category === category }"
-            @click="quickCategory(category)"
+            class="base-item"
+            :class="{ active: selectedKbId === base.kbId }"
+            @click="selectBase(base.kbId)"
           >
-            <span>{{ category }}</span>
-            <v-icon size="16">mdi-chevron-right</v-icon>
+            <div>
+              <strong>{{ base.name }}</strong>
+              <small>{{ base.description || base.kbId }}</small>
+            </div>
+            <v-chip :color="base.status === 'ACTIVE' ? 'success' : 'grey'" size="x-small" variant="tonal">
+              {{ base.documentCount || 0 }}
+            </v-chip>
           </button>
+          <div class="base-actions">
+            <v-btn icon="mdi-pencil-outline" size="x-small" variant="text" @click.stop="openBaseEdit(base)" />
+            <v-btn
+              icon="mdi-delete-outline"
+              size="x-small"
+              color="error"
+              variant="text"
+              :disabled="base.kbId === 'default'"
+              @click.stop="confirmBaseDelete(base)"
+            />
+          </div>
         </div>
       </aside>
 
-      <section class="doc-panel">
-        <div class="panel-heading board-heading">
+      <section class="panel document-panel">
+        <div class="panel-title document-heading">
           <div>
             <span>Documents</span>
-            <strong>知识文档</strong>
+            <strong>{{ selectedBaseName }}</strong>
           </div>
-          <div class="toolbar">
-            <v-btn size="small" variant="tonal" prepend-icon="mdi-refresh" @click="fetchDocs">刷新</v-btn>
-            <v-btn size="small" color="primary" prepend-icon="mdi-plus" @click="openCreateDialog">新建</v-btn>
-          </div>
+          <v-btn color="primary" size="small" prepend-icon="mdi-plus" @click="openDocCreate">新建文档</v-btn>
+        </div>
+
+        <div class="filters">
+          <v-text-field
+            v-model="filters.keyword"
+            density="compact"
+            hide-details
+            label="搜索标题、正文或分类"
+            prepend-inner-icon="mdi-magnify"
+            variant="outlined"
+            @keydown.enter="applyFilters"
+          />
+          <v-select
+            v-model="filters.category"
+            :items="categoryItems"
+            density="compact"
+            hide-details
+            item-title="title"
+            item-value="value"
+            label="分类"
+            variant="outlined"
+          />
+          <v-select
+            v-model="filters.status"
+            :items="statusFilterItems"
+            density="compact"
+            hide-details
+            item-title="title"
+            item-value="value"
+            label="状态"
+            variant="outlined"
+          />
+          <v-btn variant="tonal" prepend-icon="mdi-filter-outline" @click="applyFilters">筛选</v-btn>
         </div>
 
         <v-data-table
@@ -109,8 +138,8 @@
           density="comfortable"
           hide-default-footer
           item-key="docId"
-          @click:row="handleRowClick"
           :row-props="getRowProps"
+          @click:row="handleRowClick"
         >
           <template #item.title="{ item }">
             <div class="doc-title">
@@ -118,17 +147,15 @@
               <small>{{ item.docId }}</small>
             </div>
           </template>
+          <template #item.kbId="{ item }">
+            {{ baseName(item.kbId) }}
+          </template>
           <template #item.status="{ item }">
-            <v-chip :color="statusColor(item.status)" size="small" variant="tonal">
-              {{ statusText(item.status) }}
+            <v-chip :color="item.status === 'ACTIVE' ? 'success' : 'grey'" size="small" variant="tonal">
+              {{ item.status === 'ACTIVE' ? '启用' : '停用' }}
             </v-chip>
           </template>
-          <template #item.chunkCount="{ item }">
-            <span class="chunk-count">{{ item.chunkCount || 0 }}</span>
-          </template>
-          <template #item.modifyTime="{ item }">
-            {{ formatTime(item.modifyTime) }}
-          </template>
+          <template #item.modifyTime="{ item }">{{ formatTime(item.modifyTime) }}</template>
         </v-data-table>
 
         <div class="pager">
@@ -138,42 +165,45 @@
         </div>
       </section>
 
-      <aside class="detail-panel">
-        <div class="panel-heading board-heading">
+      <aside class="panel detail-panel">
+        <div class="panel-title">
           <div>
-            <span>Detail</span>
-            <strong>文档详情</strong>
+            <span>Document Detail</span>
+            <strong>文档与分片</strong>
           </div>
-          <v-chip v-if="selectedDetail" size="small" variant="tonal" :color="statusColor(selectedDetail.status)">
-            {{ statusText(selectedDetail.status) }}
+          <v-chip v-if="selectedDetail" size="small" variant="tonal" :color="selectedDetail.status === 'ACTIVE' ? 'success' : 'grey'">
+            {{ selectedDetail.status === 'ACTIVE' ? '启用' : '停用' }}
           </v-chip>
         </div>
 
-        <div v-if="!selectedDetail" class="empty-detail">
-          <v-icon size="32">mdi-file-search-outline</v-icon>
-          <span>选择一篇知识文档</span>
+        <div v-if="!selectedDetail" class="empty-state">
+          <v-icon size="36">mdi-file-search-outline</v-icon>
+          <span>从中间选择一篇文档</span>
         </div>
 
         <template v-else>
-          <div class="detail-title">
+          <div class="detail-head">
             <h2>{{ selectedDetail.title }}</h2>
-            <p>{{ selectedDetail.category }} · {{ selectedDetail.version }}</p>
+            <p>{{ baseName(selectedDetail.kbId) }} · {{ selectedDetail.category }} · {{ selectedDetail.version }}</p>
           </div>
           <div class="detail-actions">
-            <v-btn size="small" variant="tonal" prepend-icon="mdi-pencil" @click="openEditDialog">编辑</v-btn>
-            <v-btn size="small" variant="tonal" prepend-icon="mdi-vector-polyline" @click="rebuildSelected">重建分片</v-btn>
-            <v-btn size="small" color="error" variant="tonal" prepend-icon="mdi-delete-outline" @click="openDeleteDialog">删除</v-btn>
+            <v-btn size="small" variant="tonal" prepend-icon="mdi-pencil" @click="openDocEdit">编辑</v-btn>
+            <v-btn size="small" variant="tonal" prepend-icon="mdi-vector-polyline" :loading="rebuilding" @click="rebuildSelected">重建分片</v-btn>
+            <v-btn size="small" variant="tonal" prepend-icon="mdi-database-sync-outline" :loading="reindexing" @click="reindexSelected">重建向量</v-btn>
+            <v-btn size="small" color="error" variant="tonal" prepend-icon="mdi-delete-outline" @click="confirmDocDelete">删除</v-btn>
           </div>
 
           <div class="content-preview">{{ selectedDetail.content }}</div>
 
           <div class="chunk-list">
-            <div class="panel-heading compact">
-              <span>Chunks</span>
-              <strong>检索分片</strong>
-            </div>
-            <div v-for="chunk in selectedDetail.chunks" :key="chunk.chunkId" class="chunk-item">
-              <div>
+            <div
+              v-for="chunk in selectedDetail.chunks || []"
+              :id="`chunk-${chunk.chunkId}`"
+              :key="chunk.chunkId"
+              class="chunk-card"
+              :class="{ highlighted: highlightChunkId === chunk.chunkId }"
+            >
+              <div class="chunk-head">
                 <strong>#{{ chunk.seq }}</strong>
                 <small>{{ chunk.chunkId }}</small>
               </div>
@@ -184,10 +214,10 @@
       </aside>
     </section>
 
-    <section class="retrieve-panel">
-      <div class="panel-heading board-heading">
+    <section class="panel retrieve-panel">
+      <div class="panel-title retrieve-heading">
         <div>
-          <span>Retrieve</span>
+          <span>Retrieval Preview</span>
           <strong>检索预览</strong>
         </div>
         <v-select
@@ -195,10 +225,11 @@
           :items="retrieveScopeItems"
           density="compact"
           hide-details
-          item-title="label"
+          item-title="title"
           item-value="value"
+          label="检索范围"
           variant="outlined"
-          class="scope-select"
+          class="retrieve-scope"
         />
       </div>
       <div class="retrieve-bar">
@@ -206,7 +237,7 @@
           v-model="retrieveQuestion"
           density="comfortable"
           hide-details
-          label="问题"
+          label="输入业务问题"
           prepend-inner-icon="mdi-comment-question-outline"
           variant="outlined"
           @keydown.enter="runRetrieve"
@@ -214,160 +245,171 @@
         <v-btn color="primary" :loading="retrieving" prepend-icon="mdi-text-search" @click="runRetrieve">检索</v-btn>
       </div>
       <div class="citation-grid">
-        <article v-for="citation in citations" :key="citation.chunkId" class="citation-card">
+        <button
+          v-for="citation in citations"
+          :key="citation.chunkId"
+          type="button"
+          class="citation-card"
+          @click="openCitation(citation)"
+        >
           <div>
             <strong>{{ citation.docName || citation.docId }}</strong>
             <small>{{ citation.chunkId }}</small>
           </div>
           <p>{{ citation.snippet }}</p>
-        </article>
+        </button>
         <div v-if="!citations.length" class="empty-citation">暂无检索结果</div>
       </div>
     </section>
 
-    <v-dialog v-model="editor.visible" max-width="920" persistent>
+    <v-dialog v-model="baseEditor.visible" max-width="620" persistent>
       <v-card>
-        <v-card-title>{{ editor.mode === 'create' ? '新建知识' : '编辑知识' }}</v-card-title>
-        <v-card-text>
-          <div class="editor-grid">
-            <v-text-field v-model="editor.form.title" label="标题" variant="outlined" hide-details />
-            <v-text-field v-model="editor.form.category" label="分类" variant="outlined" hide-details />
-            <v-text-field v-model="editor.form.version" label="版本" variant="outlined" hide-details />
-            <v-select
-              v-model="editor.form.status"
-              :items="statusOptions"
-              item-title="label"
-              item-value="value"
-              label="状态"
-              variant="outlined"
-              hide-details
-            />
-            <v-text-field
-              v-model="editor.form.docId"
-              :disabled="editor.mode === 'edit'"
-              label="文档编号"
-              variant="outlined"
-              hide-details
-            />
-            <v-text-field v-model="editor.form.sourcePath" label="来源" variant="outlined" hide-details />
-          </div>
-          <v-textarea
-            v-model="editor.form.content"
-            class="mt-4"
-            label="正文"
-            rows="14"
-            auto-grow
-            variant="outlined"
-          />
+        <v-card-title>{{ baseEditor.mode === 'create' ? '新建知识库' : '编辑知识库' }}</v-card-title>
+        <v-card-text class="dialog-fields">
+          <v-text-field v-model="baseEditor.form.name" label="知识库名称" variant="outlined" />
+          <v-text-field v-model="baseEditor.form.kbId" :disabled="baseEditor.mode === 'edit'" label="知识库编号" variant="outlined" hint="留空时根据名称生成" persistent-hint />
+          <v-textarea v-model="baseEditor.form.description" label="说明" rows="3" variant="outlined" />
+          <v-select v-model="baseEditor.form.status" :items="statusOptions" item-title="title" item-value="value" label="状态" variant="outlined" />
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="closeEditor">取消</v-btn>
-          <v-btn color="primary" :loading="saving" @click="saveDoc">保存</v-btn>
+          <v-btn variant="text" @click="baseEditor.visible = false">取消</v-btn>
+          <v-btn color="primary" :loading="baseSaving" @click="saveBase">保存</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
 
-    <v-dialog v-model="deleteDialog.visible" max-width="420">
+    <v-dialog v-model="docEditor.visible" max-width="920" persistent>
       <v-card>
-        <v-card-title>删除知识文档</v-card-title>
+        <v-card-title>{{ docEditor.mode === 'create' ? '新建知识文档' : '编辑知识文档' }}</v-card-title>
         <v-card-text>
-          删除后该文档及分片将不再参与 AI 检索。
-          <strong>{{ selectedDetail?.title }}</strong>
+          <div class="editor-grid">
+            <v-select v-model="docEditor.form.kbId" :items="activeBaseItems" item-title="title" item-value="value" label="所属知识库" variant="outlined" />
+            <v-text-field v-model="docEditor.form.title" label="标题" variant="outlined" />
+            <v-text-field v-model="docEditor.form.docId" :disabled="docEditor.mode === 'edit'" label="文档编号" variant="outlined" />
+            <v-text-field v-model="docEditor.form.category" label="分类" variant="outlined" />
+            <v-text-field v-model="docEditor.form.version" label="版本" variant="outlined" />
+            <v-select v-model="docEditor.form.status" :items="statusOptions" item-title="title" item-value="value" label="状态" variant="outlined" />
+            <v-text-field v-model="docEditor.form.sourcePath" class="span-2" label="来源" variant="outlined" />
+          </div>
+          <v-textarea v-model="docEditor.form.content" label="正文" rows="14" auto-grow variant="outlined" />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="docEditor.visible = false">取消</v-btn>
+          <v-btn color="primary" :loading="docSaving" @click="saveDoc">保存</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog.visible" max-width="460">
+      <v-card>
+        <v-card-title>{{ deleteDialog.type === 'base' ? '删除知识库' : '删除知识文档' }}</v-card-title>
+        <v-card-text>
+          确认删除 <strong>{{ deleteDialog.name }}</strong>？
+          <p v-if="deleteDialog.type === 'base'" class="delete-tip">知识库中仍有文档时，后端会拒绝删除。</p>
         </v-card-text>
         <v-card-actions>
           <v-spacer />
           <v-btn variant="text" @click="deleteDialog.visible = false">取消</v-btn>
-          <v-btn color="error" :loading="deleting" @click="deleteSelected">删除</v-btn>
+          <v-btn color="error" :loading="deleting" @click="performDelete">删除</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
 
-    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="1800">
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="2200">
       {{ snackbar.text }}
     </v-snackbar>
   </main>
 </template>
 
 <script setup>
-import { computed, onMounted, reactive, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed, nextTick, onMounted, reactive, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import {
+  createKnowledgeBase,
   createKnowledgeDoc,
+  deleteKnowledgeBase,
   deleteKnowledgeDoc,
   getKnowledgeDoc,
+  listKnowledgeBases,
   listKnowledgeCategories,
   listKnowledgeDocs,
   rebuildKnowledgeDoc,
+  reindexKnowledgeDoc,
   retrieveKnowledge,
+  updateKnowledgeBase,
   updateKnowledgeDoc,
 } from '@/api/ai'
 
+const route = useRoute()
 const router = useRouter()
-
+const knowledgeBases = ref([])
 const docs = ref([])
 const total = ref(0)
+const allDocumentCount = ref(0)
 const page = ref(1)
 const size = ref(10)
 const loading = ref(false)
-const saving = ref(false)
+const baseLoading = ref(false)
+const baseSaving = ref(false)
+const docSaving = ref(false)
 const deleting = ref(false)
+const rebuilding = ref(false)
+const reindexing = ref(false)
 const retrieving = ref(false)
-const categories = ref([])
+const selectedKbId = ref('all')
 const selectedDoc = ref(null)
 const selectedDetail = ref(null)
+const categories = ref([])
 const retrieveQuestion = ref('凭证审核流程有哪些关键控制点？')
 const retrieveScope = ref('all')
 const citations = ref([])
+const highlightChunkId = ref('')
 
-const filters = reactive({
-  keyword: '',
-  category: '',
-  status: '',
-})
-
-const editor = reactive({
-  visible: false,
-  mode: 'create',
-  form: emptyForm(),
-})
-
-const deleteDialog = reactive({ visible: false })
+const filters = reactive({ keyword: '', category: '', status: '' })
+const baseEditor = reactive({ visible: false, mode: 'create', form: emptyBaseForm() })
+const docEditor = reactive({ visible: false, mode: 'create', form: emptyDocForm() })
+const deleteDialog = reactive({ visible: false, type: 'doc', id: '', name: '' })
 const snackbar = reactive({ show: false, text: '', color: 'success' })
 
 const headers = [
   { title: '标题', value: 'title', minWidth: 220 },
-  { title: '分类', value: 'category', width: 130 },
-  { title: '状态', value: 'status', width: 110 },
-  { title: '分片', value: 'chunkCount', width: 90, align: 'center' },
-  { title: '更新时间', value: 'modifyTime', width: 160 },
+  { title: '知识库', value: 'kbId', width: 150 },
+  { title: '分类', value: 'category', width: 120 },
+  { title: '状态', value: 'status', width: 90 },
+  { title: '分片', value: 'chunkCount', width: 80, align: 'center' },
+  { title: '更新时间', value: 'modifyTime', width: 150 },
 ]
-
 const statusOptions = [
-  { label: '启用', value: 'ACTIVE' },
-  { label: '停用', value: 'INACTIVE' },
+  { title: '启用', value: 'ACTIVE' },
+  { title: '停用', value: 'INACTIVE' },
 ]
-
-const statusFilterItems = [
-  { label: '全部', value: '' },
-  ...statusOptions,
-]
-
-const retrieveScopeItems = [
-  { label: '全部知识', value: 'all' },
-  { label: '当前文档', value: 'current' },
-]
-
+const statusFilterItems = [{ title: '全部状态', value: '' }, ...statusOptions]
 const categoryItems = computed(() => [
-  { label: '全部', value: '' },
-  ...categories.value.map(category => ({ label: category, value: category })),
+  { title: '全部分类', value: '' },
+  ...categories.value.map(value => ({ title: value, value })),
 ])
+const activeBaseItems = computed(() => knowledgeBases.value
+  .filter(item => item.status === 'ACTIVE')
+  .map(item => ({ title: item.name, value: item.kbId })))
+const retrieveScopeItems = computed(() => [
+  { title: '全部知识库', value: 'all' },
+  ...(selectedDetail.value ? [{ title: `当前文档：${selectedDetail.value.title}`, value: 'current' }] : []),
+  ...activeBaseItems.value,
+])
+const activeBaseCount = computed(() => knowledgeBases.value.filter(item => item.status === 'ACTIVE').length)
+const selectedBaseName = computed(() => selectedKbId.value === 'all' ? '全部知识文档' : baseName(selectedKbId.value))
+const currentPageChunkCount = computed(() => docs.value.reduce((sum, item) => sum + Number(item.chunkCount || 0), 0))
 const pageCount = computed(() => Math.max(1, Math.ceil(total.value / size.value)))
-const activeDocCount = computed(() => docs.value.filter(item => item.status === 'ACTIVE').length)
-const currentPageChunkCount = computed(() => docs.value.reduce((sum, item) => sum + (item.chunkCount || 0), 0))
 
-function emptyForm() {
+function emptyBaseForm() {
+  return { kbId: '', name: '', description: '', status: 'ACTIVE' }
+}
+
+function emptyDocForm() {
   return {
+    kbId: selectedKbId.value !== 'all' ? selectedKbId.value : 'default',
     docId: '',
     title: '',
     category: '通用知识',
@@ -375,6 +417,23 @@ function emptyForm() {
     content: '',
     version: 'v1',
     status: 'ACTIVE',
+  }
+}
+
+function baseName(kbId) {
+  return knowledgeBases.value.find(item => item.kbId === kbId)?.name || kbId || '默认知识库'
+}
+
+async function fetchBases() {
+  baseLoading.value = true
+  try {
+    const resp = await listKnowledgeBases()
+    knowledgeBases.value = resp?.data || []
+    allDocumentCount.value = knowledgeBases.value.reduce((sum, item) => sum + Number(item.documentCount || 0), 0)
+  } catch (error) {
+    showMsg('知识库加载失败', 'error')
+  } finally {
+    baseLoading.value = false
   }
 }
 
@@ -387,22 +446,19 @@ async function fetchDocs() {
       keyword: filters.keyword || undefined,
       category: filters.category || undefined,
       status: filters.status || undefined,
+      kbId: selectedKbId.value === 'all' ? undefined : selectedKbId.value,
     })
     const data = resp?.data || {}
     docs.value = data.records || []
-    total.value = data.total || 0
-    if (selectedDoc.value && !docs.value.some(item => item.docId === selectedDoc.value.docId)) {
-      selectedDoc.value = null
-      selectedDetail.value = null
-    }
+    total.value = Number(data.total || 0)
   } catch (error) {
-    showMsg('知识列表加载失败', 'error')
+    showMsg('知识文档加载失败', 'error')
   } finally {
     loading.value = false
   }
 }
 
-async function refreshCategories() {
+async function fetchCategories() {
   try {
     const resp = await listKnowledgeCategories()
     categories.value = resp?.data || []
@@ -411,19 +467,24 @@ async function refreshCategories() {
   }
 }
 
+async function refreshAll() {
+  await Promise.all([fetchBases(), fetchCategories()])
+  await fetchDocs()
+}
+
+async function selectBase(kbId) {
+  selectedKbId.value = kbId
+  page.value = 1
+  selectedDoc.value = null
+  selectedDetail.value = null
+  citations.value = []
+  retrieveScope.value = kbId
+  await fetchDocs()
+}
+
 function applyFilters() {
   page.value = 1
   fetchDocs()
-}
-
-function resetFilters() {
-  Object.assign(filters, { keyword: '', category: '', status: '' })
-  applyFilters()
-}
-
-function quickCategory(category) {
-  filters.category = category
-  applyFilters()
 }
 
 function changePage(nextPage) {
@@ -431,39 +492,86 @@ function changePage(nextPage) {
   fetchDocs()
 }
 
-function handleRowClick(_, row) {
-  const item = row?.item
-  if (!item) return
-  selectedDoc.value = item
-  loadDetail(item.docId)
-}
-
 function getRowProps({ item }) {
   return item?.docId === selectedDoc.value?.docId ? { class: 'selected-row' } : {}
 }
 
-async function loadDetail(docId) {
+function handleRowClick(_, row) {
+  if (row?.item) openDocument(row.item.docId)
+}
+
+async function openDocument(docId, chunkId = '') {
   try {
     const resp = await getKnowledgeDoc(docId)
     selectedDetail.value = resp?.data || null
+    selectedDoc.value = selectedDetail.value ? { ...selectedDetail.value } : null
+    highlightChunkId.value = chunkId
+    if (selectedDetail.value?.kbId && selectedKbId.value !== 'all') selectedKbId.value = selectedDetail.value.kbId
+    await router.replace({
+      path: '/ai/knowledge',
+      query: { docId, ...(chunkId ? { chunkId } : {}) },
+    })
+    if (chunkId) {
+      await nextTick()
+      document.getElementById(`chunk-${chunkId}`)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
   } catch (error) {
-    showMsg('知识详情加载失败', 'error')
+    showMsg('知识文档详情加载失败', 'error')
   }
 }
 
-function openCreateDialog() {
-  editor.mode = 'create'
-  editor.form = emptyForm()
-  editor.visible = true
+function openCitation(citation) {
+  openDocument(citation.docId, citation.chunkId)
 }
 
-async function openEditDialog() {
-  if (!selectedDetail.value && selectedDoc.value) {
-    await loadDetail(selectedDoc.value.docId)
+function openBaseCreate() {
+  baseEditor.mode = 'create'
+  baseEditor.form = emptyBaseForm()
+  baseEditor.visible = true
+}
+
+function openBaseEdit(base) {
+  baseEditor.mode = 'edit'
+  baseEditor.form = {
+    kbId: base.kbId,
+    name: base.name,
+    description: base.description || '',
+    status: base.status,
   }
+  baseEditor.visible = true
+}
+
+async function saveBase() {
+  if (!baseEditor.form.name.trim()) return showMsg('知识库名称不能为空', 'warning')
+  baseSaving.value = true
+  try {
+    if (baseEditor.mode === 'create') await createKnowledgeBase({ ...baseEditor.form })
+    else await updateKnowledgeBase(baseEditor.form.kbId, { ...baseEditor.form })
+    baseEditor.visible = false
+    await fetchBases()
+    showMsg('知识库已保存')
+  } catch (error) {
+    showMsg(error?.response?.data?.message || '知识库保存失败', 'error')
+  } finally {
+    baseSaving.value = false
+  }
+}
+
+function confirmBaseDelete(base) {
+  Object.assign(deleteDialog, { visible: true, type: 'base', id: base.kbId, name: base.name })
+}
+
+function openDocCreate() {
+  docEditor.mode = 'create'
+  docEditor.form = emptyDocForm()
+  docEditor.visible = true
+}
+
+function openDocEdit() {
   if (!selectedDetail.value) return
-  editor.mode = 'edit'
-  editor.form = {
+  docEditor.mode = 'edit'
+  docEditor.form = {
+    kbId: selectedDetail.value.kbId || 'default',
     docId: selectedDetail.value.docId,
     title: selectedDetail.value.title,
     category: selectedDetail.value.category,
@@ -472,62 +580,58 @@ async function openEditDialog() {
     version: selectedDetail.value.version,
     status: selectedDetail.value.status,
   }
-  editor.visible = true
-}
-
-function closeEditor() {
-  editor.visible = false
+  docEditor.visible = true
 }
 
 async function saveDoc() {
-  if (!editor.form.title.trim() || !editor.form.content.trim()) {
-    showMsg('标题和正文不能为空', 'warning')
-    return
+  if (!docEditor.form.title.trim() || !docEditor.form.content.trim()) {
+    return showMsg('标题和正文不能为空', 'warning')
   }
-  saving.value = true
+  docSaving.value = true
   try {
-    let resp
-    if (editor.mode === 'create') {
-      resp = await createKnowledgeDoc({ ...editor.form })
-    } else {
-      resp = await updateKnowledgeDoc(editor.form.docId, { ...editor.form })
-    }
+    const resp = docEditor.mode === 'create'
+      ? await createKnowledgeDoc({ ...docEditor.form })
+      : await updateKnowledgeDoc(docEditor.form.docId, { ...docEditor.form })
     const detail = resp?.data
-    selectedDetail.value = detail || selectedDetail.value
-    selectedDoc.value = detail ? { ...detail } : selectedDoc.value
-    closeEditor()
-    await refreshCategories()
-    await fetchDocs()
-    if (detail?.docId) {
-      await loadDetail(detail.docId)
-    }
-    showMsg('知识已保存')
+    docEditor.visible = false
+    await Promise.all([fetchBases(), fetchCategories(), fetchDocs()])
+    if (detail?.docId) await openDocument(detail.docId)
+    showMsg('知识文档已保存')
   } catch (error) {
-    showMsg(error?.response?.data?.message || '保存失败', 'error')
+    showMsg(error?.response?.data?.message || '知识文档保存失败', 'error')
   } finally {
-    saving.value = false
+    docSaving.value = false
   }
 }
 
-function openDeleteDialog() {
+function confirmDocDelete() {
   if (!selectedDetail.value) return
-  deleteDialog.visible = true
+  Object.assign(deleteDialog, {
+    visible: true,
+    type: 'doc',
+    id: selectedDetail.value.docId,
+    name: selectedDetail.value.title,
+  })
 }
 
-async function deleteSelected() {
-  if (!selectedDetail.value) return
+async function performDelete() {
   deleting.value = true
   try {
-    await deleteKnowledgeDoc(selectedDetail.value.docId)
+    if (deleteDialog.type === 'base') {
+      await deleteKnowledgeBase(deleteDialog.id)
+      if (selectedKbId.value === deleteDialog.id) selectedKbId.value = 'all'
+    } else {
+      await deleteKnowledgeDoc(deleteDialog.id)
+      selectedDoc.value = null
+      selectedDetail.value = null
+      highlightChunkId.value = ''
+      await router.replace('/ai/knowledge')
+    }
     deleteDialog.visible = false
-    selectedDoc.value = null
-    selectedDetail.value = null
-    citations.value = []
-    await refreshCategories()
-    await fetchDocs()
-    showMsg('知识已删除')
+    await refreshAll()
+    showMsg('删除成功')
   } catch (error) {
-    showMsg('删除失败', 'error')
+    showMsg(error?.response?.data?.message || '删除失败', 'error')
   } finally {
     deleting.value = false
   }
@@ -535,32 +639,42 @@ async function deleteSelected() {
 
 async function rebuildSelected() {
   if (!selectedDetail.value) return
+  rebuilding.value = true
   try {
     await rebuildKnowledgeDoc(selectedDetail.value.docId)
-    await loadDetail(selectedDetail.value.docId)
+    await openDocument(selectedDetail.value.docId)
     await fetchDocs()
-    showMsg('分片已重建')
+    showMsg('分片和向量已重建')
   } catch (error) {
-    showMsg('重建失败', 'error')
+    showMsg('分片重建失败', 'error')
+  } finally {
+    rebuilding.value = false
+  }
+}
+
+async function reindexSelected() {
+  if (!selectedDetail.value) return
+  reindexing.value = true
+  try {
+    const resp = await reindexKnowledgeDoc(selectedDetail.value.docId)
+    const status = resp?.data?.status || 'INDEXED'
+    showMsg(`向量索引完成：${status}`)
+  } catch (error) {
+    showMsg(error?.response?.data?.message || '向量索引失败', 'error')
+  } finally {
+    reindexing.value = false
   }
 }
 
 async function runRetrieve() {
-  if (!retrieveQuestion.value.trim()) {
-    showMsg('请输入问题', 'warning')
-    return
-  }
-  if (retrieveScope.value === 'current' && !selectedDetail.value) {
-    showMsg('请选择当前文档', 'warning')
-    return
-  }
+  if (!retrieveQuestion.value.trim()) return showMsg('请输入问题', 'warning')
+  if (retrieveScope.value === 'current' && !selectedDetail.value) return showMsg('请先选择文档', 'warning')
   retrieving.value = true
   try {
-    const resp = await retrieveKnowledge({
-      question: retrieveQuestion.value.trim(),
-      kbIds: retrieveScope.value === 'current' ? [selectedDetail.value.docId] : ['default'],
-      topK: 6,
-    })
+    const kbIds = retrieveScope.value === 'current'
+      ? [selectedDetail.value.docId]
+      : [retrieveScope.value || 'all']
+    const resp = await retrieveKnowledge({ question: retrieveQuestion.value.trim(), kbIds, topK: 6 })
     citations.value = resp?.data || []
   } catch (error) {
     showMsg('检索失败', 'error')
@@ -569,21 +683,8 @@ async function runRetrieve() {
   }
 }
 
-function goAssistant() {
-  router.push('/ai/assistant')
-}
-
-function statusText(status) {
-  return status === 'ACTIVE' ? '启用' : '停用'
-}
-
-function statusColor(status) {
-  return status === 'ACTIVE' ? 'success' : 'grey'
-}
-
 function formatTime(value) {
-  if (!value) return '-'
-  return String(value).replace('T', ' ').slice(0, 16)
+  return value ? String(value).replace('T', ' ').slice(0, 16) : '-'
 }
 
 function showMsg(text, color = 'success') {
@@ -593,7 +694,10 @@ function showMsg(text, color = 'success') {
 }
 
 onMounted(async () => {
-  await Promise.all([refreshCategories(), fetchDocs()])
+  await refreshAll()
+  const docId = typeof route.query.docId === 'string' ? route.query.docId : ''
+  const chunkId = typeof route.query.chunkId === 'string' ? route.query.chunkId : ''
+  if (docId) await openDocument(docId, chunkId)
 })
 </script>
 
@@ -610,166 +714,162 @@ onMounted(async () => {
   display: flex;
   align-items: end;
   justify-content: space-between;
-  gap: 20px;
-  padding: 26px;
-  border: 1px solid rgba(23, 42, 52, 0.1);
-  border-radius: 8px;
-  color: #ffffff;
-  background:
-    linear-gradient(135deg, rgba(12, 82, 91, 0.96) 0%, rgba(18, 126, 105, 0.94) 56%, rgba(47, 62, 71, 0.98) 100%);
-  box-shadow: 0 20px 50px rgba(26, 42, 58, 0.15);
+  gap: 24px;
+  padding: 28px;
+  border-radius: 14px;
+  color: #fff;
+  background: linear-gradient(135deg, #0c525b 0%, #127e69 58%, #293945 100%);
+  box-shadow: 0 20px 50px rgba(26, 42, 58, 0.16);
 }
 
 .eyebrow,
-.panel-heading span {
-  color: #d9b35c;
+.panel-title span {
+  color: #e0bd6b;
   font-size: 12px;
   font-weight: 900;
-  letter-spacing: 0;
   text-transform: uppercase;
 }
 
 .hero-row h1 {
-  margin: 8px 0 8px;
+  margin: 8px 0;
   font-size: 38px;
-  line-height: 1.1;
 }
 
 .hero-row p {
   max-width: 720px;
   margin: 0;
   color: rgba(255, 255, 255, 0.82);
-  line-height: 1.75;
 }
 
-.hero-actions {
+.hero-actions,
+.detail-actions,
+.retrieve-bar,
+.filters {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 10px;
+  flex-wrap: wrap;
 }
 
 .metric-row {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 14px;
-  margin-top: 16px;
+  margin: 16px 0;
 }
 
-.metric-tile,
-.filter-panel,
-.doc-panel,
-.detail-panel,
-.retrieve-panel {
+.metric-card,
+.panel {
   border: 1px solid rgba(23, 42, 52, 0.09);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.94);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.96);
   box-shadow: 0 14px 34px rgba(34, 53, 73, 0.07);
 }
 
-.metric-tile {
+.metric-card {
   display: grid;
   gap: 5px;
-  min-height: 96px;
-  align-content: center;
-  padding: 16px;
+  padding: 17px;
 }
 
-.metric-tile span,
-.metric-tile small {
+.metric-card span,
+.metric-card small,
+.doc-title small,
+.base-item small,
+.detail-head p,
+.chunk-head small,
+.citation-card small {
   color: #6c7784;
   font-size: 12px;
 }
 
-.metric-tile strong {
-  color: #102431;
-  font-size: 27px;
-  line-height: 1;
+.metric-card strong {
+  font-size: 28px;
 }
 
 .workspace-grid {
   display: grid;
-  grid-template-columns: 240px minmax(0, 1fr) 370px;
+  grid-template-columns: 250px minmax(0, 1fr) 390px;
   gap: 16px;
-  margin-top: 16px;
 }
 
-.filter-panel,
-.doc-panel,
-.detail-panel,
-.retrieve-panel {
+.panel {
   padding: 18px;
 }
 
-.filter-panel {
-  align-self: start;
-  display: grid;
-  gap: 12px;
-}
-
-.panel-heading {
+.panel-title {
   display: flex;
-  flex-direction: column;
-  gap: 3px;
-  margin-bottom: 12px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
 }
 
-.panel-heading strong {
+.panel-title > div:first-child {
+  display: grid;
+  gap: 3px;
+}
+
+.panel-title strong {
   font-size: 19px;
 }
 
-.panel-heading.compact strong {
-  font-size: 16px;
+.base-panel {
+  align-self: start;
 }
 
-.board-heading {
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+.base-item-wrap {
+  position: relative;
+  margin-bottom: 8px;
 }
 
-.toolbar,
-.filter-actions,
-.detail-actions,
-.retrieve-bar {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.filter-actions {
-  flex-direction: column;
-}
-
-.category-stack {
-  display: grid;
-  gap: 8px;
-  margin-top: 6px;
-}
-
-.category-stack button {
-  min-height: 40px;
+.base-item {
+  width: 100%;
+  min-height: 66px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 0 10px;
-  border: 0;
-  border-radius: 8px;
-  color: #344252;
-  background: #f4f7f7;
+  padding: 10px 70px 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  text-align: left;
+  background: #f5f8f8;
   cursor: pointer;
 }
 
-.category-stack button.active,
-.category-stack button:hover {
-  color: #0c5f62;
-  background: #e5f4ef;
+.base-item > div {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
 }
 
-.knowledge-table {
-  border: 1px solid rgba(23, 42, 52, 0.06);
-  border-radius: 8px;
+.base-item small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.base-item.active {
+  border-color: rgba(18, 126, 105, 0.3);
+  background: #e9f6f1;
+}
+
+.base-actions {
+  position: absolute;
+  top: 18px;
+  right: 5px;
+  display: flex;
+}
+
+.document-panel {
+  min-width: 0;
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) 150px 130px auto;
+  margin-bottom: 12px;
 }
 
 .doc-title {
@@ -777,124 +877,99 @@ onMounted(async () => {
   gap: 3px;
 }
 
-.doc-title strong {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.doc-title small {
-  color: #75808c;
-  font-size: 12px;
-}
-
-.chunk-count {
-  font-weight: 900;
-}
-
-:deep(.selected-row) {
-  background: #e7f4f1 !important;
+.selected-row {
+  background: #edf8f4 !important;
 }
 
 .pager {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  margin-top: 12px;
-  color: #607080;
+  gap: 12px;
+  margin-top: 10px;
   font-size: 13px;
 }
 
 .detail-panel {
-  align-self: start;
-  max-height: 720px;
+  max-height: 920px;
   overflow: auto;
 }
 
-.empty-detail,
+.empty-state,
 .empty-citation {
-  min-height: 180px;
+  min-height: 150px;
   display: grid;
-  place-items: center;
-  align-content: center;
+  place-content: center;
   gap: 8px;
-  color: #778390;
+  color: #7a8792;
+  text-align: center;
 }
 
-.detail-title h2 {
-  margin: 0;
-  font-size: 21px;
-  line-height: 1.3;
+.detail-head h2 {
+  margin: 0 0 6px;
+  font-size: 22px;
 }
 
-.detail-title p {
-  margin: 6px 0 0;
-  color: #6f7b87;
-}
-
-.detail-actions {
-  flex-wrap: wrap;
-  margin-top: 14px;
+.detail-head p {
+  margin: 0 0 12px;
 }
 
 .content-preview {
-  max-height: 260px;
+  max-height: 220px;
   overflow: auto;
-  margin-top: 14px;
+  margin: 14px 0;
   padding: 14px;
-  border-radius: 8px;
-  color: #263343;
-  background: #f7f9fa;
-  line-height: 1.75;
+  border-radius: 10px;
+  color: #354452;
+  background: #f5f7f8;
   white-space: pre-wrap;
-  word-break: break-word;
+  line-height: 1.65;
 }
 
 .chunk-list {
-  margin-top: 16px;
-}
-
-.chunk-item {
   display: grid;
-  gap: 8px;
-  padding: 12px 0;
-  border-top: 1px solid rgba(23, 42, 52, 0.08);
+  gap: 10px;
 }
 
-.chunk-item div {
+.chunk-card {
+  padding: 12px;
+  border: 1px solid rgba(23, 42, 52, 0.08);
+  border-radius: 10px;
+  background: #fff;
+  transition: 0.25s ease;
+}
+
+.chunk-card.highlighted {
+  border-color: #d4a943;
+  background: #fff8df;
+  box-shadow: 0 0 0 3px rgba(212, 169, 67, 0.14);
+}
+
+.chunk-head {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
+  gap: 8px;
 }
 
-.chunk-item small {
-  overflow: hidden;
-  color: #7b8792;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.chunk-item p {
-  margin: 0;
-  color: #3e4b58;
-  line-height: 1.65;
+.chunk-card p,
+.citation-card p {
+  margin: 8px 0 0;
+  color: #465564;
+  line-height: 1.6;
 }
 
 .retrieve-panel {
   margin-top: 16px;
 }
 
-.scope-select {
-  max-width: 180px;
+.retrieve-scope {
+  min-width: 260px;
+  max-width: 420px;
 }
 
 .retrieve-bar {
-  align-items: stretch;
-}
-
-.retrieve-bar .v-input {
-  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
 }
 
 .citation-grid {
@@ -905,31 +980,23 @@ onMounted(async () => {
 }
 
 .citation-card {
-  min-height: 150px;
-  display: grid;
-  gap: 10px;
-  align-content: start;
+  min-height: 130px;
   padding: 14px;
-  border: 1px solid rgba(23, 42, 52, 0.08);
-  border-radius: 8px;
-  background: #f8faf9;
+  border: 1px solid rgba(23, 42, 52, 0.09);
+  border-radius: 10px;
+  text-align: left;
+  background: #fff;
+  cursor: pointer;
 }
 
-.citation-card strong,
-.citation-card small {
-  display: block;
+.citation-card:hover {
+  border-color: rgba(18, 126, 105, 0.36);
+  transform: translateY(-1px);
 }
 
-.citation-card small {
-  margin-top: 4px;
-  color: #778390;
-  font-size: 12px;
-}
-
-.citation-card p {
-  margin: 0;
-  color: #3c4856;
-  line-height: 1.7;
+.citation-card > div {
+  display: grid;
+  gap: 3px;
 }
 
 .editor-grid {
@@ -938,46 +1005,56 @@ onMounted(async () => {
   gap: 12px;
 }
 
-@media (max-width: 1240px) {
+.span-2 {
+  grid-column: 1 / -1;
+}
+
+.dialog-fields {
+  display: grid;
+  gap: 4px;
+}
+
+.delete-tip {
+  margin: 10px 0 0;
+  color: #7a4d20;
+}
+
+@media (max-width: 1280px) {
   .workspace-grid {
-    grid-template-columns: 220px minmax(0, 1fr);
+    grid-template-columns: 230px minmax(0, 1fr);
   }
 
   .detail-panel {
     grid-column: 1 / -1;
     max-height: none;
   }
-
-  .citation-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
 }
 
-@media (max-width: 820px) {
+@media (max-width: 900px) {
   .knowledge-page {
     padding: 14px;
   }
 
-  .hero-row,
-  .board-heading,
-  .retrieve-bar {
-    align-items: stretch;
+  .hero-row {
+    align-items: start;
     flex-direction: column;
   }
 
   .metric-row,
   .workspace-grid,
   .citation-grid,
+  .filters,
   .editor-grid {
     grid-template-columns: 1fr;
   }
 
-  .hero-row h1 {
-    font-size: 32px;
+  .retrieve-bar {
+    grid-template-columns: 1fr;
   }
 
-  .scope-select {
-    max-width: none;
+  .retrieve-scope {
+    min-width: 100%;
+    max-width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
## What changed

Frontend workbench for Matrix Knowledge Base Phase 3A.

### Knowledge workbench

- knowledge-base navigation and CRUD
- document filtering by knowledge base, category, status, and keyword
- assign or move documents between active knowledge bases
- document and chunk detail
- chunk rebuild and vector reindex actions
- retrieval preview against all knowledge, one knowledge base, or one document

### AI assistant integration

- select one or more active knowledge bases before sending a question
- send the selected IDs through `kbIds`
- deep-link citations to `/ai/knowledge?docId=...&chunkId=...`
- automatically load the cited document, scroll to the exact chunk, and highlight it

### CI

Added `.github/workflows/knowledge-web-ci.yml` so AI knowledge views, API bindings, routes, and package changes run:

- `npm ci`
- `npm run build`

Latest head `e5bfa9f0a74bd35618f183368c03150b80cbf856` passed Knowledge Web CI.

## Backend dependency and deployment order

Depends on matrix PR #78.

1. Apply backend migration `sql/bizfi_ai_knowledge_base_v4.sql`.
2. Deploy matrix PR #78.
3. Verify `default` knowledge base and migrated documents.
4. Deploy this frontend.
5. Test all-base, one-base, and one-document retrieval plus citation chunk highlighting.