### PR TITLE
feat(knowledge): add file ingestion workbench

### DIFF
--- a/.github/workflows/knowledge-web-ci.yml
+++ b/.github/workflows/knowledge-web-ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - dev
+      - 'agent/knowledge-*'
     paths:
       - 'src/views/ai/**'
       - 'src/api/ai.js'
+      - 'src/api/knowledge*.js'
       - 'src/router/index.js'
       - 'package.json'
       - 'package-lock.json'
@@ -18,6 +20,7 @@ on:
     paths:
       - 'src/views/ai/**'
       - 'src/api/ai.js'
+      - 'src/api/knowledge*.js'
       - 'src/router/index.js'
       - 'package.json'
       - 'package-lock.json'

--- a/src/api/knowledgeIngestion.js
+++ b/src/api/knowledgeIngestion.js
@@ -11,7 +11,6 @@ export function getKnowledgeIngestionConfig() {
 export function importKnowledgeFile(formData) {
   return request.post('/ai/knowledge/import', formData, {
     timeout: INGESTION_TIMEOUT,
-    headers: { 'Content-Type': 'multipart/form-data' },
   })
 }
 

--- a/src/api/knowledgeIngestion.js
+++ b/src/api/knowledgeIngestion.js
@@ -1,0 +1,35 @@
+import request from '@/utils/request'
+
+const INGESTION_TIMEOUT = 120000
+
+export function getKnowledgeIngestionConfig() {
+  return request.get('/ai/knowledge/ingestion/config', {
+    timeout: INGESTION_TIMEOUT,
+  })
+}
+
+export function importKnowledgeFile(formData) {
+  return request.post('/ai/knowledge/import', formData, {
+    timeout: INGESTION_TIMEOUT,
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+}
+
+export function listKnowledgeIndexJobs(params = {}) {
+  return request.get('/ai/knowledge/index-jobs', {
+    params,
+    timeout: INGESTION_TIMEOUT,
+  })
+}
+
+export function retryKnowledgeIndexJob(jobId) {
+  return request.post(`/ai/knowledge/index-jobs/${jobId}/retry`, {}, {
+    timeout: INGESTION_TIMEOUT,
+  })
+}
+
+export function enqueueKnowledgeIndexJob(docId) {
+  return request.post(`/ai/knowledge/docs/${docId}/index-jobs`, {}, {
+    timeout: INGESTION_TIMEOUT,
+  })
+}

--- a/src/views/ai/KnowledgeSystemView.vue
+++ b/src/views/ai/KnowledgeSystemView.vue
@@ -4,7 +4,7 @@
       <div>
         <span class="eyebrow">Matrix Knowledge</span>
         <h1>企业知识系统</h1>
-        <p>按知识库组织制度、流程、案例和业务口径，并作为 AI 助手可追溯的引用来源。</p>
+        <p>按知识库组织制度、流程、案例和业务口径，并通过文件导入、异步索引和可追溯引用持续沉淀。</p>
       </div>
       <div class="hero-actions">
         <v-btn color="primary" prepend-icon="mdi-database-plus-outline" @click="openBaseCreate">新建知识库</v-btn>
@@ -36,6 +36,12 @@
       </article>
     </section>
 
+    <KnowledgeIngestionPanel
+      :knowledge-bases="knowledgeBases"
+      :selected-kb-id="selectedKbId"
+      @imported="handleImported"
+    />
+
     <section class="workspace-grid">
       <aside class="panel base-panel">
         <div class="panel-title">
@@ -46,12 +52,7 @@
           <v-btn icon="mdi-refresh" size="small" variant="text" :loading="baseLoading" @click="refreshAll" />
         </div>
 
-        <button
-          type="button"
-          class="base-item"
-          :class="{ active: selectedKbId === 'all' }"
-          @click="selectBase('all')"
-        >
+        <button type="button" class="base-item" :class="{ active: selectedKbId === 'all' }" @click="selectBase('all')">
           <div>
             <strong>全部知识</strong>
             <small>跨知识库检索</small>
@@ -60,12 +61,7 @@
         </button>
 
         <div v-for="base in knowledgeBases" :key="base.kbId" class="base-item-wrap">
-          <button
-            type="button"
-            class="base-item"
-            :class="{ active: selectedKbId === base.kbId }"
-            @click="selectBase(base.kbId)"
-          >
+          <button type="button" class="base-item" :class="{ active: selectedKbId === base.kbId }" @click="selectBase(base.kbId)">
             <div>
               <strong>{{ base.name }}</strong>
               <small>{{ base.description || base.kbId }}</small>
@@ -89,7 +85,7 @@
       </aside>
 
       <section class="panel document-panel">
-        <div class="panel-title document-heading">
+        <div class="panel-title">
           <div>
             <span>Documents</span>
             <strong>{{ selectedBaseName }}</strong>
@@ -147,9 +143,7 @@
               <small>{{ item.docId }}</small>
             </div>
           </template>
-          <template #item.kbId="{ item }">
-            {{ baseName(item.kbId) }}
-          </template>
+          <template #item.kbId="{ item }">{{ baseName(item.kbId) }}</template>
           <template #item.status="{ item }">
             <v-chip :color="item.status === 'ACTIVE' ? 'success' : 'grey'" size="small" variant="tonal">
               {{ item.status === 'ACTIVE' ? '启用' : '停用' }}
@@ -189,12 +183,11 @@
           <div class="detail-actions">
             <v-btn size="small" variant="tonal" prepend-icon="mdi-pencil" @click="openDocEdit">编辑</v-btn>
             <v-btn size="small" variant="tonal" prepend-icon="mdi-vector-polyline" :loading="rebuilding" @click="rebuildSelected">重建分片</v-btn>
-            <v-btn size="small" variant="tonal" prepend-icon="mdi-database-sync-outline" :loading="reindexing" @click="reindexSelected">重建向量</v-btn>
+            <v-btn size="small" variant="tonal" prepend-icon="mdi-database-clock-outline" :loading="reindexing" @click="reindexSelected">异步重建向量</v-btn>
             <v-btn size="small" color="error" variant="tonal" prepend-icon="mdi-delete-outline" @click="confirmDocDelete">删除</v-btn>
           </div>
 
           <div class="content-preview">{{ selectedDetail.content }}</div>
-
           <div class="chunk-list">
             <div
               v-for="chunk in selectedDetail.chunks || []"
@@ -267,7 +260,7 @@
         <v-card-title>{{ baseEditor.mode === 'create' ? '新建知识库' : '编辑知识库' }}</v-card-title>
         <v-card-text class="dialog-fields">
           <v-text-field v-model="baseEditor.form.name" label="知识库名称" variant="outlined" />
-          <v-text-field v-model="baseEditor.form.kbId" :disabled="baseEditor.mode === 'edit'" label="知识库编号" variant="outlined" hint="留空时根据名称生成" persistent-hint />
+          <v-text-field v-model="baseEditor.form.kbId" :disabled="baseEditor.mode === 'edit'" label="知识库编号" variant="outlined" hint="留空时自动生成" persistent-hint />
           <v-textarea v-model="baseEditor.form.description" label="说明" rows="3" variant="outlined" />
           <v-select v-model="baseEditor.form.status" :items="statusOptions" item-title="title" item-value="value" label="状态" variant="outlined" />
         </v-card-text>
@@ -317,9 +310,7 @@
       </v-card>
     </v-dialog>
 
-    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="2200">
-      {{ snackbar.text }}
-    </v-snackbar>
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="2200">{{ snackbar.text }}</v-snackbar>
   </main>
 </template>
 
@@ -336,11 +327,12 @@ import {
   listKnowledgeCategories,
   listKnowledgeDocs,
   rebuildKnowledgeDoc,
-  reindexKnowledgeDoc,
   retrieveKnowledge,
   updateKnowledgeBase,
   updateKnowledgeDoc,
 } from '@/api/ai'
+import { enqueueKnowledgeIndexJob } from '@/api/knowledgeIngestion'
+import KnowledgeIngestionPanel from '@/views/ai/components/KnowledgeIngestionPanel.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -472,6 +464,12 @@ async function refreshAll() {
   await fetchDocs()
 }
 
+async function handleImported(docId) {
+  await refreshAll()
+  await openDocument(docId)
+  showMsg('文件已导入，向量索引将在后台完成')
+}
+
 async function selectBase(kbId) {
   selectedKbId.value = kbId
   page.value = 1
@@ -506,11 +504,7 @@ async function openDocument(docId, chunkId = '') {
     selectedDetail.value = resp?.data || null
     selectedDoc.value = selectedDetail.value ? { ...selectedDetail.value } : null
     highlightChunkId.value = chunkId
-    if (selectedDetail.value?.kbId && selectedKbId.value !== 'all') selectedKbId.value = selectedDetail.value.kbId
-    await router.replace({
-      path: '/ai/knowledge',
-      query: { docId, ...(chunkId ? { chunkId } : {}) },
-    })
+    await router.replace({ path: '/ai/knowledge', query: { docId, ...(chunkId ? { chunkId } : {}) } })
     if (chunkId) {
       await nextTick()
       document.getElementById(`chunk-${chunkId}`)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
@@ -532,12 +526,7 @@ function openBaseCreate() {
 
 function openBaseEdit(base) {
   baseEditor.mode = 'edit'
-  baseEditor.form = {
-    kbId: base.kbId,
-    name: base.name,
-    description: base.description || '',
-    status: base.status,
-  }
+  baseEditor.form = { kbId: base.kbId, name: base.name, description: base.description || '', status: base.status }
   baseEditor.visible = true
 }
 
@@ -584,9 +573,7 @@ function openDocEdit() {
 }
 
 async function saveDoc() {
-  if (!docEditor.form.title.trim() || !docEditor.form.content.trim()) {
-    return showMsg('标题和正文不能为空', 'warning')
-  }
+  if (!docEditor.form.title.trim() || !docEditor.form.content.trim()) return showMsg('标题和正文不能为空', 'warning')
   docSaving.value = true
   try {
     const resp = docEditor.mode === 'create'
@@ -594,7 +581,7 @@ async function saveDoc() {
       : await updateKnowledgeDoc(docEditor.form.docId, { ...docEditor.form })
     const detail = resp?.data
     docEditor.visible = false
-    await Promise.all([fetchBases(), fetchCategories(), fetchDocs()])
+    await refreshAll()
     if (detail?.docId) await openDocument(detail.docId)
     showMsg('知识文档已保存')
   } catch (error) {
@@ -606,12 +593,7 @@ async function saveDoc() {
 
 function confirmDocDelete() {
   if (!selectedDetail.value) return
-  Object.assign(deleteDialog, {
-    visible: true,
-    type: 'doc',
-    id: selectedDetail.value.docId,
-    name: selectedDetail.value.title,
-  })
+  Object.assign(deleteDialog, { visible: true, type: 'doc', id: selectedDetail.value.docId, name: selectedDetail.value.title })
 }
 
 async function performDelete() {
@@ -644,9 +626,9 @@ async function rebuildSelected() {
     await rebuildKnowledgeDoc(selectedDetail.value.docId)
     await openDocument(selectedDetail.value.docId)
     await fetchDocs()
-    showMsg('分片和向量已重建')
+    showMsg('分片已重建')
   } catch (error) {
-    showMsg('分片重建失败', 'error')
+    showMsg(error?.response?.data?.message || '分片重建失败', 'error')
   } finally {
     rebuilding.value = false
   }
@@ -656,11 +638,10 @@ async function reindexSelected() {
   if (!selectedDetail.value) return
   reindexing.value = true
   try {
-    const resp = await reindexKnowledgeDoc(selectedDetail.value.docId)
-    const status = resp?.data?.status || 'INDEXED'
-    showMsg(`向量索引完成：${status}`)
+    await enqueueKnowledgeIndexJob(selectedDetail.value.docId)
+    showMsg('向量索引任务已进入后台队列')
   } catch (error) {
-    showMsg(error?.response?.data?.message || '向量索引失败', 'error')
+    showMsg(error?.response?.data?.message || '索引任务创建失败', 'error')
   } finally {
     reindexing.value = false
   }
@@ -671,9 +652,7 @@ async function runRetrieve() {
   if (retrieveScope.value === 'current' && !selectedDetail.value) return showMsg('请先选择文档', 'warning')
   retrieving.value = true
   try {
-    const kbIds = retrieveScope.value === 'current'
-      ? [selectedDetail.value.docId]
-      : [retrieveScope.value || 'all']
+    const kbIds = retrieveScope.value === 'current' ? [selectedDetail.value.docId] : [retrieveScope.value || 'all']
     const resp = await retrieveKnowledge({ question: retrieveQuestion.value.trim(), kbIds, topK: 6 })
     citations.value = resp?.data || []
   } catch (error) {
@@ -730,26 +709,12 @@ onMounted(async () => {
   text-transform: uppercase;
 }
 
-.hero-row h1 {
-  margin: 8px 0;
-  font-size: 38px;
-}
-
-.hero-row p {
-  max-width: 720px;
-  margin: 0;
-  color: rgba(255, 255, 255, 0.82);
-}
-
+.hero-row h1 { margin: 8px 0; font-size: 38px; }
+.hero-row p { max-width: 760px; margin: 0; color: rgba(255, 255, 255, 0.82); line-height: 1.7; }
 .hero-actions,
 .detail-actions,
 .retrieve-bar,
-.filters {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
+.filters { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 
 .metric-row {
   display: grid;
@@ -766,26 +731,15 @@ onMounted(async () => {
   box-shadow: 0 14px 34px rgba(34, 53, 73, 0.07);
 }
 
-.metric-card {
-  display: grid;
-  gap: 5px;
-  padding: 17px;
-}
-
+.metric-card { display: grid; gap: 5px; padding: 17px; }
 .metric-card span,
 .metric-card small,
 .doc-title small,
 .base-item small,
 .detail-head p,
 .chunk-head small,
-.citation-card small {
-  color: #6c7784;
-  font-size: 12px;
-}
-
-.metric-card strong {
-  font-size: 28px;
-}
+.citation-card small { color: #6c7784; font-size: 12px; }
+.metric-card strong { font-size: 28px; }
 
 .workspace-grid {
   display: grid;
@@ -793,35 +747,12 @@ onMounted(async () => {
   gap: 16px;
 }
 
-.panel {
-  padding: 18px;
-}
-
-.panel-title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 14px;
-}
-
-.panel-title > div:first-child {
-  display: grid;
-  gap: 3px;
-}
-
-.panel-title strong {
-  font-size: 19px;
-}
-
-.base-panel {
-  align-self: start;
-}
-
-.base-item-wrap {
-  position: relative;
-  margin-bottom: 8px;
-}
+.panel { padding: 18px; }
+.panel-title { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 14px; }
+.panel-title > div:first-child { display: grid; gap: 3px; }
+.panel-title strong { font-size: 19px; }
+.base-panel { align-self: start; }
+.base-item-wrap { position: relative; margin-bottom: 8px; }
 
 .base-item {
   width: 100%;
@@ -838,81 +769,20 @@ onMounted(async () => {
   cursor: pointer;
 }
 
-.base-item > div {
-  min-width: 0;
-  display: grid;
-  gap: 4px;
-}
-
-.base-item small {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.base-item.active {
-  border-color: rgba(18, 126, 105, 0.3);
-  background: #e9f6f1;
-}
-
-.base-actions {
-  position: absolute;
-  top: 18px;
-  right: 5px;
-  display: flex;
-}
-
-.document-panel {
-  min-width: 0;
-}
-
-.filters {
-  display: grid;
-  grid-template-columns: minmax(220px, 1fr) 150px 130px auto;
-  margin-bottom: 12px;
-}
-
-.doc-title {
-  display: grid;
-  gap: 3px;
-}
-
-.selected-row {
-  background: #edf8f4 !important;
-}
-
-.pager {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  margin-top: 10px;
-  font-size: 13px;
-}
-
-.detail-panel {
-  max-height: 920px;
-  overflow: auto;
-}
-
+.base-item > div { min-width: 0; display: grid; gap: 4px; }
+.base-item small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.base-item.active { border-color: rgba(18, 126, 105, 0.3); background: #e9f6f1; }
+.base-actions { position: absolute; top: 18px; right: 5px; display: flex; }
+.document-panel { min-width: 0; }
+.filters { display: grid; grid-template-columns: minmax(220px, 1fr) 150px 130px auto; margin-bottom: 12px; }
+.doc-title { display: grid; gap: 3px; }
+.selected-row { background: #edf8f4 !important; }
+.pager { display: flex; align-items: center; justify-content: center; gap: 12px; margin-top: 10px; font-size: 13px; }
+.detail-panel { max-height: 920px; overflow: auto; }
 .empty-state,
-.empty-citation {
-  min-height: 150px;
-  display: grid;
-  place-content: center;
-  gap: 8px;
-  color: #7a8792;
-  text-align: center;
-}
-
-.detail-head h2 {
-  margin: 0 0 6px;
-  font-size: 22px;
-}
-
-.detail-head p {
-  margin: 0 0 12px;
-}
+.empty-citation { min-height: 150px; display: grid; place-content: center; gap: 8px; color: #7a8792; text-align: center; }
+.detail-head h2 { margin: 0 0 6px; font-size: 22px; }
+.detail-head p { margin: 0 0 12px; }
 
 .content-preview {
   max-height: 220px;
@@ -926,58 +796,16 @@ onMounted(async () => {
   line-height: 1.65;
 }
 
-.chunk-list {
-  display: grid;
-  gap: 10px;
-}
-
-.chunk-card {
-  padding: 12px;
-  border: 1px solid rgba(23, 42, 52, 0.08);
-  border-radius: 10px;
-  background: #fff;
-  transition: 0.25s ease;
-}
-
-.chunk-card.highlighted {
-  border-color: #d4a943;
-  background: #fff8df;
-  box-shadow: 0 0 0 3px rgba(212, 169, 67, 0.14);
-}
-
-.chunk-head {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
-}
-
+.chunk-list { display: grid; gap: 10px; }
+.chunk-card { padding: 12px; border: 1px solid rgba(23, 42, 52, 0.08); border-radius: 10px; background: #fff; transition: 0.25s ease; }
+.chunk-card.highlighted { border-color: #d4a943; background: #fff8df; box-shadow: 0 0 0 3px rgba(212, 169, 67, 0.14); }
+.chunk-head { display: flex; justify-content: space-between; gap: 8px; }
 .chunk-card p,
-.citation-card p {
-  margin: 8px 0 0;
-  color: #465564;
-  line-height: 1.6;
-}
-
-.retrieve-panel {
-  margin-top: 16px;
-}
-
-.retrieve-scope {
-  min-width: 260px;
-  max-width: 420px;
-}
-
-.retrieve-bar {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-}
-
-.citation-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
-  margin-top: 14px;
-}
+.citation-card p { margin: 8px 0 0; color: #465564; line-height: 1.6; }
+.retrieve-panel { margin-top: 16px; }
+.retrieve-scope { min-width: 260px; max-width: 420px; }
+.retrieve-bar { display: grid; grid-template-columns: minmax(0, 1fr) auto; }
+.citation-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin-top: 14px; }
 
 .citation-card {
   min-height: 130px;
@@ -989,72 +817,27 @@ onMounted(async () => {
   cursor: pointer;
 }
 
-.citation-card:hover {
-  border-color: rgba(18, 126, 105, 0.36);
-  transform: translateY(-1px);
-}
-
-.citation-card > div {
-  display: grid;
-  gap: 3px;
-}
-
-.editor-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.span-2 {
-  grid-column: 1 / -1;
-}
-
-.dialog-fields {
-  display: grid;
-  gap: 4px;
-}
-
-.delete-tip {
-  margin: 10px 0 0;
-  color: #7a4d20;
-}
+.citation-card:hover { border-color: rgba(18, 126, 105, 0.36); transform: translateY(-1px); }
+.citation-card > div { display: grid; gap: 3px; }
+.editor-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.span-2 { grid-column: 1 / -1; }
+.dialog-fields { display: grid; gap: 4px; }
+.delete-tip { margin: 10px 0 0; color: #7a4d20; }
 
 @media (max-width: 1280px) {
-  .workspace-grid {
-    grid-template-columns: 230px minmax(0, 1fr);
-  }
-
-  .detail-panel {
-    grid-column: 1 / -1;
-    max-height: none;
-  }
+  .workspace-grid { grid-template-columns: 230px minmax(0, 1fr); }
+  .detail-panel { grid-column: 1 / -1; max-height: none; }
 }
 
 @media (max-width: 900px) {
-  .knowledge-page {
-    padding: 14px;
-  }
-
-  .hero-row {
-    align-items: start;
-    flex-direction: column;
-  }
-
+  .knowledge-page { padding: 14px; }
+  .hero-row { align-items: start; flex-direction: column; }
   .metric-row,
   .workspace-grid,
   .citation-grid,
   .filters,
-  .editor-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .retrieve-bar {
-    grid-template-columns: 1fr;
-  }
-
-  .retrieve-scope {
-    min-width: 100%;
-    max-width: 100%;
-  }
+  .editor-grid { grid-template-columns: 1fr; }
+  .retrieve-bar { grid-template-columns: 1fr; }
+  .retrieve-scope { min-width: 100%; max-width: 100%; }
 }
 </style>

--- a/src/views/ai/components/KnowledgeIngestionPanel.vue
+++ b/src/views/ai/components/KnowledgeIngestionPanel.vue
@@ -1,0 +1,464 @@
+<template>
+  <section class="ingestion-panel">
+    <div class="panel-head">
+      <div>
+        <span>File Ingestion</span>
+        <strong>文件导入与异步索引</strong>
+      </div>
+      <div class="head-actions">
+        <v-chip :color="config.enabled ? 'success' : 'warning'" size="small" variant="tonal">
+          {{ config.enabled ? '已启用' : '未启用' }}
+        </v-chip>
+        <v-btn icon="mdi-refresh" size="small" variant="text" :loading="jobsLoading" @click="refreshJobs" />
+      </div>
+    </div>
+
+    <v-alert v-if="!config.enabled" type="warning" variant="tonal" density="compact" class="mb-4">
+      后端文件导入尚未启用。执行 V5 迁移后设置 AI_KNOWLEDGE_INGESTION_ENABLED=true。
+    </v-alert>
+
+    <div class="import-grid">
+      <v-file-input
+        v-model="fileModel"
+        :disabled="!config.enabled || uploading"
+        :accept="acceptTypes"
+        label="选择 PDF、Word、TXT 或 Markdown"
+        prepend-icon="mdi-paperclip"
+        variant="outlined"
+        density="comfortable"
+        show-size
+        clearable
+      />
+      <v-select
+        v-model="form.kbId"
+        :items="baseItems"
+        :disabled="!config.enabled || uploading"
+        item-title="title"
+        item-value="value"
+        label="导入到知识库"
+        variant="outlined"
+        density="comfortable"
+      />
+      <v-text-field
+        v-model="form.title"
+        :disabled="!config.enabled || uploading"
+        label="标题（留空使用文件名）"
+        variant="outlined"
+        density="comfortable"
+      />
+      <v-text-field
+        v-model="form.category"
+        :disabled="!config.enabled || uploading"
+        label="分类"
+        variant="outlined"
+        density="comfortable"
+      />
+      <v-text-field
+        v-model="form.version"
+        :disabled="!config.enabled || uploading"
+        label="版本"
+        variant="outlined"
+        density="comfortable"
+      />
+      <v-select
+        v-model="form.status"
+        :items="statusItems"
+        :disabled="!config.enabled || uploading"
+        item-title="title"
+        item-value="value"
+        label="文档状态"
+        variant="outlined"
+        density="comfortable"
+      />
+    </div>
+
+    <div class="import-actions">
+      <div>
+        <small>最大 {{ maxSizeText }}；扫描版 PDF 暂不包含 OCR。</small>
+        <p v-if="notice.text" :class="['notice', notice.type]">{{ notice.text }}</p>
+      </div>
+      <v-btn
+        color="primary"
+        prepend-icon="mdi-cloud-upload-outline"
+        :disabled="!config.enabled || !selectedFile"
+        :loading="uploading"
+        @click="upload"
+      >
+        导入并创建索引任务
+      </v-btn>
+    </div>
+
+    <div class="job-section">
+      <div class="job-title">
+        <strong>最近索引任务</strong>
+        <small>{{ jobs.length }} 条</small>
+      </div>
+      <div v-if="jobsLoading && !jobs.length" class="job-empty">正在读取索引任务…</div>
+      <div v-else-if="!jobs.length" class="job-empty">暂无文件导入或异步索引任务</div>
+      <div v-else class="job-list">
+        <article v-for="job in jobs" :key="job.jobId" class="job-card">
+          <div class="job-main">
+            <div>
+              <strong>{{ job.fileName || job.docId }}</strong>
+              <small>{{ baseName(job.kbId) }} · {{ job.docId }}</small>
+            </div>
+            <v-chip :color="jobColor(job.status)" size="small" variant="tonal">
+              {{ jobStatusText(job.status) }}
+            </v-chip>
+          </div>
+          <v-progress-linear
+            :model-value="jobProgress(job.status)"
+            :indeterminate="job.status === 'RUNNING'"
+            height="5"
+            rounded
+          />
+          <div class="job-meta">
+            <span>尝试 {{ job.attempts || 0 }}/{{ job.maxAttempts || 0 }}</span>
+            <span>{{ formatTime(job.modifyTime || job.createTime) }}</span>
+            <span>{{ formatBytes(job.fileSize) }}</span>
+          </div>
+          <p v-if="job.errorMessage" class="job-error">{{ job.errorMessage }}</p>
+          <div v-if="retryable(job.status)" class="job-actions">
+            <v-btn
+              size="small"
+              variant="tonal"
+              prepend-icon="mdi-reload"
+              :loading="retryingJobId === job.jobId"
+              @click="retry(job)"
+            >
+              重新排队
+            </v-btn>
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import {
+  getKnowledgeIngestionConfig,
+  importKnowledgeFile,
+  listKnowledgeIndexJobs,
+  retryKnowledgeIndexJob,
+} from '@/api/knowledgeIngestion'
+
+const props = defineProps({
+  knowledgeBases: { type: Array, default: () => [] },
+  selectedKbId: { type: String, default: 'all' },
+})
+const emit = defineEmits(['imported'])
+
+const config = reactive({
+  enabled: false,
+  maxFileSizeBytes: 10 * 1024 * 1024,
+  maxExtractedCharacters: 2_000_000,
+  allowedExtensions: ['pdf', 'doc', 'docx', 'txt', 'md', 'markdown'],
+})
+const form = reactive({ kbId: 'default', title: '', category: '导入文档', version: 'v1', status: 'ACTIVE' })
+const notice = reactive({ text: '', type: 'success' })
+const fileModel = ref([])
+const jobs = ref([])
+const uploading = ref(false)
+const jobsLoading = ref(false)
+const retryingJobId = ref('')
+let pollTimer = null
+
+const statusItems = [
+  { title: '启用', value: 'ACTIVE' },
+  { title: '停用', value: 'INACTIVE' },
+]
+const baseItems = computed(() => props.knowledgeBases
+  .filter(item => item.status === 'ACTIVE')
+  .map(item => ({ title: item.name, value: item.kbId })))
+const selectedFile = computed(() => {
+  if (Array.isArray(fileModel.value)) return fileModel.value[0] || null
+  return fileModel.value || null
+})
+const acceptTypes = computed(() => (config.allowedExtensions || [])
+  .map(extension => `.${extension}`)
+  .join(','))
+const maxSizeText = computed(() => formatBytes(config.maxFileSizeBytes))
+
+watch(() => props.selectedKbId, (value) => {
+  if (value && value !== 'all' && baseItems.value.some(item => item.value === value)) form.kbId = value
+}, { immediate: true })
+
+watch(baseItems, (items) => {
+  if (!items.some(item => item.value === form.kbId)) form.kbId = items[0]?.value || 'default'
+}, { immediate: true })
+
+async function fetchConfig() {
+  try {
+    const resp = await getKnowledgeIngestionConfig()
+    Object.assign(config, resp?.data || {})
+  } catch (error) {
+    config.enabled = false
+    setNotice('无法读取文件导入配置', 'error')
+  }
+}
+
+async function refreshJobs() {
+  jobsLoading.value = true
+  try {
+    const resp = await listKnowledgeIndexJobs({ limit: 30 })
+    jobs.value = resp?.data || []
+  } catch (error) {
+    if (config.enabled) setNotice('索引任务加载失败', 'error')
+  } finally {
+    jobsLoading.value = false
+  }
+}
+
+async function upload() {
+  const file = selectedFile.value
+  if (!file) return setNotice('请选择需要导入的文件', 'warning')
+  if (Number(file.size || 0) > Number(config.maxFileSizeBytes || 0)) {
+    return setNotice(`文件不能超过 ${maxSizeText.value}`, 'warning')
+  }
+  uploading.value = true
+  try {
+    const payload = new FormData()
+    payload.append('file', file)
+    payload.append('kbId', form.kbId || 'default')
+    if (form.title.trim()) payload.append('title', form.title.trim())
+    if (form.category.trim()) payload.append('category', form.category.trim())
+    if (form.version.trim()) payload.append('version', form.version.trim())
+    payload.append('status', form.status)
+    const resp = await importKnowledgeFile(payload)
+    const document = resp?.data?.document
+    fileModel.value = []
+    form.title = ''
+    setNotice(`已导入 ${document?.title || file.name}，索引任务已进入队列`, 'success')
+    await refreshJobs()
+    if (document?.docId) emit('imported', document.docId)
+  } catch (error) {
+    setNotice(error?.response?.data?.message || '文件导入失败', 'error')
+  } finally {
+    uploading.value = false
+  }
+}
+
+async function retry(job) {
+  retryingJobId.value = job.jobId
+  try {
+    await retryKnowledgeIndexJob(job.jobId)
+    setNotice('索引任务已重新排队', 'success')
+    await refreshJobs()
+  } catch (error) {
+    setNotice(error?.response?.data?.message || '任务重试失败', 'error')
+  } finally {
+    retryingJobId.value = ''
+  }
+}
+
+function retryable(status) {
+  return ['FAILED', 'PARTIAL', 'SKIPPED'].includes(status)
+}
+
+function jobProgress(status) {
+  if (status === 'PENDING') return 12
+  if (status === 'RUNNING') return 55
+  return 100
+}
+
+function jobColor(status) {
+  if (status === 'SUCCEEDED') return 'success'
+  if (status === 'RUNNING') return 'primary'
+  if (status === 'PENDING') return 'info'
+  if (status === 'PARTIAL' || status === 'SKIPPED') return 'warning'
+  return 'error'
+}
+
+function jobStatusText(status) {
+  return {
+    PENDING: '等待中',
+    RUNNING: '索引中',
+    SUCCEEDED: '已完成',
+    PARTIAL: '部分成功',
+    SKIPPED: '已跳过',
+    FAILED: '失败',
+  }[status] || status || '未知'
+}
+
+function baseName(kbId) {
+  return props.knowledgeBases.find(item => item.kbId === kbId)?.name || kbId || '默认知识库'
+}
+
+function formatTime(value) {
+  return value ? String(value).replace('T', ' ').slice(0, 16) : '-'
+}
+
+function formatBytes(value) {
+  const bytes = Number(value || 0)
+  if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${bytes} B`
+}
+
+function setNotice(text, type = 'success') {
+  notice.text = text
+  notice.type = type
+}
+
+onMounted(async () => {
+  await Promise.all([fetchConfig(), refreshJobs()])
+  pollTimer = window.setInterval(() => {
+    if (jobs.value.some(item => ['PENDING', 'RUNNING'].includes(item.status))) refreshJobs()
+  }, 5000)
+})
+
+onBeforeUnmount(() => {
+  if (pollTimer) window.clearInterval(pollTimer)
+})
+</script>
+
+<style scoped>
+.ingestion-panel {
+  margin: 16px 0;
+  padding: 18px;
+  border: 1px solid rgba(23, 42, 52, 0.09);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 14px 34px rgba(34, 53, 73, 0.07);
+}
+
+.panel-head,
+.job-main,
+.job-title,
+.import-actions,
+.job-meta,
+.head-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panel-head {
+  margin-bottom: 16px;
+}
+
+.panel-head > div:first-child {
+  display: grid;
+  gap: 3px;
+}
+
+.panel-head span {
+  color: #d1a848;
+  font-size: 12px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.panel-head strong {
+  font-size: 19px;
+}
+
+.import-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 1.4fr) repeat(2, minmax(150px, 0.8fr));
+  gap: 12px;
+}
+
+.import-actions {
+  margin-top: 2px;
+}
+
+.import-actions small,
+.job-title small,
+.job-main small,
+.job-meta {
+  color: #6c7784;
+  font-size: 12px;
+}
+
+.notice {
+  margin: 5px 0 0;
+  font-size: 13px;
+}
+
+.notice.success { color: #16715f; }
+.notice.warning { color: #8a6519; }
+.notice.error { color: #b43838; }
+
+.job-section {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(23, 42, 52, 0.08);
+}
+
+.job-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.job-card {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid rgba(23, 42, 52, 0.08);
+  border-radius: 10px;
+  background: #f8faf9;
+}
+
+.job-main > div:first-child {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.job-main strong,
+.job-main small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.job-meta {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.job-error {
+  margin: 0;
+  color: #a93e3e;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.job-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.job-empty {
+  min-height: 90px;
+  display: grid;
+  place-content: center;
+  color: #7a8792;
+}
+
+@media (max-width: 1100px) {
+  .import-grid,
+  .job-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .import-grid,
+  .job-list {
+    grid-template-columns: 1fr;
+  }
+
+  .import-actions,
+  .panel-head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+</style>


### PR DESCRIPTION
## What changed

Phase 3B frontend for file ingestion and persistent indexing jobs, stacked on matrix-web PR #60.

### Import workbench

- imports PDF, DOC, DOCX, TXT and Markdown files
- selects target knowledge base, category, version and document status
- reads backend capability, file limits and supported extensions
- blocks oversized files before upload
- lets the browser/Axios generate the multipart boundary
- refreshes the knowledge list and opens the imported document after success

### Async indexing operations

- displays recent persistent indexing jobs
- shows PENDING, RUNNING, SUCCEEDED, PARTIAL, SKIPPED and FAILED states
- polls only while active jobs exist
- shows attempts, timestamps, file size and failure reason
- supports manual retry for failed, partial or skipped tasks
- changes manual vector rebuild into asynchronous enqueue instead of blocking the page on Embedding

### Disabled state

When backend ingestion is disabled, the panel shows the required V5 migration and environment flag. Backend PR #79 guarantees that the disabled panel does not cause V5 table access.

### Validation

Latest head `9d5ca04067294dd30dfd93d205189975953a2be9` passed Knowledge Web CI:

- `npm ci`
- `npm run build`

## Dependencies and deployment order

1. Merge/deploy matrix PR #78 and matrix-web PR #60.
2. Merge matrix PR #79.
3. Apply `sql/bizfi_ai_knowledge_ingestion_v5.sql`.
4. Deploy backend with ingestion disabled and verify existing behavior.
5. Enable `AI_KNOWLEDGE_INGESTION_ENABLED=true`.
6. Deploy this frontend.
7. Validate TXT/Markdown, PDF and DOCX imports plus retry behavior.